### PR TITLE
Improve translation prompt: use simple vocabulary and keep gaming terms in English

### DIFF
--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -24,10 +24,22 @@ async function translate(text: string, targetLang: Language): Promise<string> {
     model: GPT_MODEL,
     messages: [
       {
-        role: 'user',
-        content: `Translate the following Markdown document to ${targetLang}. Preserve all Markdown formatting, code blocks, and structure exactly. Only translate the text content, not the Markdown syntax itself:\n\n${text}`,
+        role: "system",
+        content: `You are a game localizer for roleplay servers. Translate naturally while preserving Markdown syntax.`,
       },
-    ]
+      {
+        role: "user",
+        content: `Translate this DarkRP rulebook to ${targetLang}.
+
+Rules:
+- Use simple, clear vocabulary (avoid literary/formal words)
+- Keep gaming terms in English: "fading door", "cooldown", "pry bar", "prying", "crowbar", "weed", "RDM/RDA", "NLR", "FearRP", "minging", "raid", "hit", "prop"
+- Translate "mug/mugging" with terms meaning "rob/robbery" or "hold up" in the target language
+- Preserve all Markdown formatting exactly
+
+${text}`,
+      },
+    ],
   });
 
   const content = completion.choices[0]?.message?.content;


### PR DESCRIPTION
The French translation was really disgusting (incomprehensible) so I took the liberty of making some changes to keep some of the English terms and other things that for us French people are more important.
Sometimes the AI needs context, otherwise it translates word for word

Adding a role system message allows the ai to work better, I've been using it at work for a while and it's much better.

## Changes (copilot summary)

This pull request updates the translation prompt logic in the `translate` function to improve localization quality for game rulebooks. The changes clarify instructions for the language model, ensuring gaming terms are preserved in English and Markdown formatting is strictly maintained.

Prompt improvements for game localization:

* Changed the initial prompt `role` from `'user'` to `'system'` and added a system message instructing the model to act as a game localizer and preserve Markdown syntax.
* Updated the user prompt to include specific translation guidelines: use simple vocabulary, keep gaming terms in English, translate "mug/mugging" appropriately, and strictly preserve Markdown formatting.