### PR TITLE
fix(wire): Equal gate always true when comparing string to empty input

### DIFF
--- a/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
+++ b/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
@@ -246,9 +246,9 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 
 	private bool IsEqual( object? a, object? b )
 	{
-		if ( a is string strA && b is string strB )
+		if ( a is string || b is string )
 		{
-			return strA.Equals( strB, StringComparison.Ordinal );
+			return (a?.ToString() ?? "").Equals( b?.ToString() ?? "", StringComparison.Ordinal );
 		}
 
 		var numA = ConvertToFloat( a );


### PR DESCRIPTION
When one input of an Equal/NotEqual gate was disconnected, comparing it
against a string would always return true. The string comparison branch was
only entered if both sides were strings null would fall through to numeric
conversion, where any non-numeric string and null both become 0f.

Fix: if either side is a string, use string comparison instead.