### PR TITLE
fix(cloak): fix several bugs with admin cloak

### DIFF
--- a/game/Code/Player/Player.Interact.cs
+++ b/game/Code/Player/Player.Interact.cs
@@ -6,7 +6,7 @@ public partial class Player : IContextualObject, Component.IPressable
 	public Vector3 ContextPosition => WorldPosition + Controller.BodyHeight * 0.60f * Vector3.Up;
 	public bool ShouldShow()
 	{
-		return !IsDead && !IsLocalPlayer && !string.IsNullOrWhiteSpace( Job.Interaction );
+		return !IsDead && !IsLocalPlayer && !HasStatus( Constants.CloakStatus ) && !string.IsNullOrWhiteSpace( Job.Interaction );
 	}
 	public float ContextMaxDistance => Config.Current.Game.PlayerInteractDistance;
 	public bool LookOpacity => false;

--- a/game/Code/Player/Status/Statuses/CloakStatus.cs
+++ b/game/Code/Player/Status/Statuses/CloakStatus.cs
@@ -8,6 +8,8 @@ public class CloakStatus : BaseStatus
 	public override Color Color => Color.FromRgb( 0x9E9E9E );
 
 	public override bool RemoveOnDeath => true;
+	public override bool RemoveOnRespawn => true;
+	public override bool RemoveOnJobChange => true;
 
 	public override void OnAddedBroadcast( Player player )
 	{

--- a/game/Code/System/Minigame/MinigameSystem.Player.cs
+++ b/game/Code/System/Minigame/MinigameSystem.Player.cs
@@ -22,6 +22,7 @@ public partial class MinigameSystem
 			player.SpawnHost( true );
 		}
 
+		player.RemoveStatus( Constants.CloakStatus );
 		player.RemoveStatus( Constants.WeedHighStatus );
 		player.RemoveStatus( Constants.SatiatedStatus );
 		player.HealthComponent.Health = player.HealthComponent.MaxHealth;


### PR DESCRIPTION
Hitman prompt on cloaked players, ShouldShow() now skips cloaked players so the "place a hit" hint no longer leaks on invisible admins.

Minigame join while cloaked, cloak is now stripped in PreparePlayerBaseline to avoid entering with disabled physics

Status pill stuck after job change added RemoveOnJobChange and RemoveOnRespawn to CloakStatus so the HUD stays in sync when SpawnHost