### PR TITLE
fix(chat): Fix overflow input Chat component

### DIFF
--- a/game/Code/UI/HUD/Chat/Chat.razor.scss
+++ b/game/Code/UI/HUD/Chat/Chat.razor.scss
@@ -202,6 +202,8 @@ Chat {
       align-items: center;
       gap: 8px;
       border-radius: 6px;
+      overflow: hidden;
+      width: 100%;
     }
 
     .hints {
@@ -257,7 +259,10 @@ Chat {
       border-radius: 0;
       box-shadow: none;
       transition: none;
-      flex: 1 1 auto;
+      flex: 1 1 0%;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
       display: flex;
       align-items: center;
 


### PR DESCRIPTION
Set `flex: 1 1 0%`, `min-width: 0` and `overflow: hidden` on `.chat-input` so the TextEntry no longer expands to its content width when typing a long message. Also added `overflow: hidden` and `width: 100%` to `.input-area` to properly constrain the input within the flex layout.

Before : 
<img width="463" height="38" alt="image" src="https://github.com/user-attachments/assets/0173364f-e0a6-490d-98dd-65416fbed649" />

After : 
<img width="464" height="29" alt="image" src="https://github.com/user-attachments/assets/2315248e-b5bb-42d3-bc92-204101491982" />
