### PR TITLE
fix(ui): keep dismissed votes hidden after Tab / job change

### DIFF
--- a/game/Code/UI/HUD/Voting.razor
+++ b/game/Code/UI/HUD/Voting.razor
@@ -4,7 +4,9 @@
 
 <root class="voting flex flex-col">
 	@{
-		if(!VoteSystem.Instance.IsValid()) return;
+		if ( !VoteSystem.Instance.IsValid() ) return;
+
+		CleanDismissedVotes();
 
 		var votes = VoteSystem.Instance.ActiveVotes
 			.Where( vote => !_dismissedVotes.Contains( vote.Key ) )
@@ -90,7 +92,7 @@
 
 @code
 {
-	private readonly HashSet<Guid> _dismissedVotes = [];
+	private static readonly HashSet<Guid> _dismissedVotes = [];
 
 	private void CastVote( Guid voteId, bool inFavor )
 	{
@@ -106,10 +108,17 @@
 	private void DismissVote( Guid voteId )
 	{
 		_dismissedVotes.Add( voteId );
+		StateHasChanged();
 	}
 
-	private void CleanDismissedVotes()
+	private static void CleanDismissedVotes()
 	{
+		if ( !VoteSystem.Instance.IsValid() )
+		{
+			_dismissedVotes.Clear();
+			return;
+		}
+
 		_dismissedVotes.RemoveWhere( voteId => !VoteSystem.Instance.ActiveVotes.ContainsKey( voteId ) );
 	}
 


### PR DESCRIPTION
Dismissed vote IDs were stored on the `Voting` panel instance. When Tab opens, `HUD.razor` bails out early (`HudHidden`) and the whole HUD tree, including `Voting` gets torn down. 
Close Tab, component comes back fresh, `_dismissedVotes` is empty, every active vote shows up again

Same thing if you hide votes then pick a job from Tab: menu closes, HUD remounts, votes pop back

Moved the dismissed set to a static `HashSet<Guid>` on the client, same idea as `AdminTickets.TicketLayouts`. Cleanup still runs when votes leave `ActiveVotes`
