### PR TITLE
fix(spectate): zero movement input and disable controller look while spectating

### DIFF
--- a/game/Code/Player/MoveModes/MoveModeSpectate.cs
+++ b/game/Code/Player/MoveModes/MoveModeSpectate.cs
@@ -61,9 +61,16 @@ public class MoveModeSpectate : MoveMode
 		return Vector3.Zero;
 	}
 
+	public override void AddVelocity()
+	{
+		Controller.Body.Velocity = Vector3.Zero;
+	}
+
 	public override void OnModeBegin()
 	{
 		base.OnModeBegin();
+
+		ClearLocalMovement();
 		
 		var player = GameObject.Root.GetComponent<Player>();
 		if ( !player.IsValid() )
@@ -85,6 +92,10 @@ public class MoveModeSpectate : MoveMode
 			Controller.Body.PhysicsBody.BodyType = PhysicsBodyType.Dynamic;
 		}
 
+		Controller.WishVelocity = Vector3.Zero;
+		Controller.GroundVelocity = Vector3.Zero;
+		Controller.Body.Velocity = Vector3.Zero;
+
 		var player = GameObject.Root.GetComponent<Player>();
 		if ( !player.IsValid() )
 			return;
@@ -100,6 +111,7 @@ public class MoveModeSpectate : MoveMode
 	public void StartSpectating( GameObject target )
 	{
 		_isFreeLookToggled = true;
+		ClearLocalMovement();
 		SetSpectateTarget( target );
 		SetSpectateTargetOwner( target );
 
@@ -144,6 +156,13 @@ public class MoveModeSpectate : MoveMode
 		{
 			_isFreeLookToggled = false;
 		}
+	}
+
+	private void ClearLocalMovement()
+	{
+		Controller.WishVelocity = Vector3.Zero;
+		Controller.GroundVelocity = Vector3.Zero;
+		Controller.Body.Velocity = Vector3.Zero;
 	}
 
 	public bool TryGetSpectateTargetPlayer( out Player targetPlayer )

--- a/game/Code/Player/Player.Camera.cs
+++ b/game/Code/Player/Player.Camera.cs
@@ -134,7 +134,13 @@ public partial class Player
 	{
 		UpdateFreeLook();
 
-		Controller.UseLookControls = !LockCamera;
+		var spectateMode = Controller.Components.Get<MoveModeSpectate>();
+		var isSpectatingOther =
+			spectateMode.IsValid()
+			&& Controller.Mode == spectateMode
+			&& spectateMode.SpectateTarget.IsValid();
+
+		Controller.UseLookControls = !LockCamera && !isSpectatingOther;
 
 		if ( HealthComponent.State == LifeState.Alive && Input.Pressed( "View" ) && CanChangeView )
 		{

--- a/game/Code/System/Rendering/FreeLookCameraSystem.cs
+++ b/game/Code/System/Rendering/FreeLookCameraSystem.cs
@@ -148,6 +148,15 @@ public class FreeLookCameraSystem : GameObjectSystem<FreeLookCameraSystem>
 
 	private Rotation ResolveTrackedFreeLookRotation( Player player, Angles baseAngles )
 	{
+		if ( TryGetSpectateTargetPlayer( player, out _ )
+		     && !IsSpectateFreelookEnabled( player )
+		     && !Input.Down( "FreeLook" ) )
+		{
+			_isTrackedFreeLooking = false;
+			_wasTrackedFreeLookDown = false;
+			return baseAngles.ToRotation();
+		}
+
 		var freeLookDown = Input.Down( "FreeLook" ) || IsSpectateFreelookEnabled( player );
 
 		if ( freeLookDown && !_wasTrackedFreeLookDown )


### PR DESCRIPTION
Zero out velocity / wish when entering spectate and each frame via AddVelocity, so held movement keys no longer keep the observer sliding until spectate ends

Disable controller look controls while spectating so FreeLookCameraSystem owns the view, the spectator pawn no longer turns with the mouse in “follow target” mode

Reset tracked freelook state in pure follow mode (no FreeLook key) so leftover mouse deltas don’t keep rotating the view after toggling modes