### PR TITLE
fix(gag): prevent sanctioning players with higher ranks

### DIFF
--- a/game/Code/Chat/Commands/BanCommand.cs
+++ b/game/Code/Chat/Commands/BanCommand.cs
@@ -37,7 +37,7 @@ public class BanCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
 			return true;
 		}
 		var durationDisplay = permanent

--- a/game/Code/Chat/Commands/BanCommand.cs
+++ b/game/Code/Chat/Commands/BanCommand.cs
@@ -37,7 +37,7 @@ public class BanCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
+			caller.SendMessage( "#command.sanction.cannot_target_higher_rank" );
 			return true;
 		}
 		var durationDisplay = permanent

--- a/game/Code/Chat/Commands/GagCommand.cs
+++ b/game/Code/Chat/Commands/GagCommand.cs
@@ -35,7 +35,7 @@ public class GagCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
+			caller.SendMessage( "#command.sanction.cannot_target_higher_rank" );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/GagCommand.cs
+++ b/game/Code/Chat/Commands/GagCommand.cs
@@ -33,6 +33,12 @@ public class GagCommand : ICommand
 		if ( !targetPlayer.IsValid() )
 			return true;
 
+		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
+		{
+			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			return true;
+		}
+
 		_ = ServerApiClient.SanctionPlayer( targetPlayer.SteamId, new CreateSanctionDto
 		{
 			Reason = reason,

--- a/game/Code/Chat/Commands/GagCommand.cs
+++ b/game/Code/Chat/Commands/GagCommand.cs
@@ -35,7 +35,7 @@ public class GagCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/JailCommand.cs
+++ b/game/Code/Chat/Commands/JailCommand.cs
@@ -35,7 +35,7 @@ public class JailCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/JailCommand.cs
+++ b/game/Code/Chat/Commands/JailCommand.cs
@@ -35,7 +35,7 @@ public class JailCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
+			caller.SendMessage( "#command.sanction.cannot_target_higher_rank" );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/KickCommand.cs
+++ b/game/Code/Chat/Commands/KickCommand.cs
@@ -26,7 +26,7 @@ public class KickCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
+			caller.SendMessage( "#command.sanction.cannot_target_higher_rank" );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/KickCommand.cs
+++ b/game/Code/Chat/Commands/KickCommand.cs
@@ -26,7 +26,7 @@ public class KickCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/WarnCommand.cs
+++ b/game/Code/Chat/Commands/WarnCommand.cs
@@ -26,7 +26,7 @@ public class WarnCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
+			caller.SendMessage( "#command.sanction.cannot_target_higher_rank" );
 			return true;
 		}
 

--- a/game/Code/Chat/Commands/WarnCommand.cs
+++ b/game/Code/Chat/Commands/WarnCommand.cs
@@ -26,7 +26,7 @@ public class WarnCommand : ICommand
 
 		if ( !RankSystem.CanTarget( caller.SteamId, targetPlayer.SteamId ) )
 		{
-			caller.SendMessage( "You cannot sanction a player with a higher rank." );
+			caller.SendMessage( Language.GetPhrase( "command.sanction.cannot_target_higher_rank" ) );
 			return true;
 		}
 

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -148,6 +148,7 @@
   "command.ban.duration_permanent": "permanently",
   "command.ban.duration_temporary": "for {0}",
   "command.ban.success": "Banned {0} {1}: {2}",
+  "command.sanction.cannot_target_higher_rank": "You cannot sanction a player with a higher rank.",
   "command.clearprops.not_found": "No player found matching '{0}'",
   "command.clearprops.multiple": "Multiple players found matching '{0}': {1}",
   "command.clearprops.cleared_for": "Cleared all props for {0}",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -148,6 +148,7 @@
   "command.ban.duration_permanent": "définitivement",
   "command.ban.duration_temporary": "pendant {0}",
   "command.ban.success": "Banni {0} {1} : {2}",
+  "command.sanction.cannot_target_higher_rank": "Vous ne pouvez pas sanctionner un joueur de rang supérieur au vôtre.",
   "command.clearprops.not_found": "Aucun joueur trouvé pour '{0}'",
   "command.clearprops.multiple": "Plusieurs joueurs trouvés pour '{0}' : {1}",
   "command.clearprops.cleared_for": "Tous les props de {0} ont été supprimés",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -148,6 +148,7 @@
   "command.ban.duration_permanent": "영구적으로",
   "command.ban.duration_temporary": "{0} 동안",
   "command.ban.success": "{0}을(를) {1} 동안 밴했습니다: {2}",
+  "command.sanction.cannot_target_higher_rank": "자신보다 높은 등급의 플레이어는 제재할 수 없습니다.",
   "command.clearprops.not_found": "'{0}'와 일치하는 플레이어를 찾을 수 없습니다.",
   "command.clearprops.multiple": "'{0}'와 일치하는 플레이어가 여러 명입니다: {1}",
   "command.clearprops.cleared_for": "{0}의 모든 프롭을 제거했습니다.",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -148,6 +148,7 @@
   "command.ban.duration_permanent": "permanentnie",
   "command.ban.duration_temporary": "na {0}",
   "command.ban.success": "Zbanowano {0} {1}: {2}",
+  "command.sanction.cannot_target_higher_rank": "Nie możesz ukarać gracza o wyższej randze.",
   "command.clearprops.not_found": "Nie znaleziono gracza pasującego do '{0}'",
   "command.clearprops.multiple": "Znaleziono wielu graczy pasujących do '{0}': {1}",
   "command.clearprops.cleared_for": "Usunięto wszystkie obiekty gracza {0}",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -148,6 +148,7 @@
   "command.ban.duration_permanent": "навсегда",
   "command.ban.duration_temporary": "на {0}",
   "command.ban.success": "Забанен {0} {1}: {2}",
+  "command.sanction.cannot_target_higher_rank": "Вы не можете санкционировать игрока с более высоким рангом.",
   "command.clearprops.not_found": "Игрок '{0}' не найден",
   "command.clearprops.multiple": "Найдено несколько игроков '{0}': {1}",
   "command.clearprops.cleared_for": "Все пропы игрока {0} удалены",


### PR DESCRIPTION
Rank validation check to the `GagCommand` to prevent players from sanctioning others with a higher rank