### PR TITLE
Feature/mayor police damage multiplier

### DIFF
--- a/game/Code/Config/GameConfig.Governance.cs
+++ b/game/Code/Config/GameConfig.Governance.cs
@@ -12,6 +12,7 @@ public abstract partial class GameConfig
 	public virtual bool GovernanceLawEnabled { get; set; } = true;
 	public virtual bool GovernanceMayorAnnounceEnabled { get; set; } = true;
 	public virtual bool GovernanceWantedEnabled { get; set; } = true;
+	public virtual float GovernanceMayorPoliceDamageMultiplier { get; set; } = 0f;
 
 
 	// Laws

--- a/game/Code/Config/GameConfig.Governance.cs
+++ b/game/Code/Config/GameConfig.Governance.cs
@@ -13,6 +13,7 @@ public abstract partial class GameConfig
 	public virtual bool GovernanceMayorAnnounceEnabled { get; set; } = true;
 	public virtual bool GovernanceWantedEnabled { get; set; } = true;
 	public virtual float GovernanceMayorPoliceDamageMultiplier { get; set; } = 0f;
+	public virtual float GovernancePoliceDamageMultiplier { get; set; } = 0f;
 
 
 	// Laws

--- a/game/Code/Config/Overrides/SandboxGameConfig.cs
+++ b/game/Code/Config/Overrides/SandboxGameConfig.cs
@@ -41,6 +41,7 @@ public class SandboxGameConfig : GameConfig
 	public override bool GovernanceJailEnabled { get; set; } = false;
 	public override bool GovernanceMayorAnnounceEnabled { get; set; } = false;
 	public override float GovernanceMayorPoliceDamageMultiplier { get; set; } = 1f;
+	public override float GovernancePoliceDamageMultiplier { get; set; } = 1f;
 	public override float GovernanceAnnouncementDuration { get; set; } = 0f;
 
 	// Minigames

--- a/game/Code/Config/Overrides/SandboxGameConfig.cs
+++ b/game/Code/Config/Overrides/SandboxGameConfig.cs
@@ -40,6 +40,7 @@ public class SandboxGameConfig : GameConfig
 	public override bool GovernanceLockdownEnabled { get; set; } = false;
 	public override bool GovernanceJailEnabled { get; set; } = false;
 	public override bool GovernanceMayorAnnounceEnabled { get; set; } = false;
+	public override float GovernanceMayorPoliceDamageMultiplier { get; set; } = 1f;
 	public override float GovernanceAnnouncementDuration { get; set; } = 0f;
 
 	// Minigames

--- a/game/Code/Player/Player.Health.cs
+++ b/game/Code/Player/Player.Health.cs
@@ -46,7 +46,7 @@ public partial class Player
 
 	void IDamageEvents.OnModifyDamageTaken( Component victim, ref DamageInfo damageInfo )
 	{
-		if ( ApplyMayorPoliceDamageMultiplier( ref damageInfo ) )
+		if ( ApplyGovernanceDamageMultipliers( ref damageInfo ) )
 		{
 			return;
 		}
@@ -58,20 +58,30 @@ public partial class Player
 		}
 	}
 
-	private bool ApplyMayorPoliceDamageMultiplier( ref DamageInfo damageInfo )
+	private bool ApplyGovernanceDamageMultipliers( ref DamageInfo damageInfo )
 	{
-		if ( !Job.IsMayoralRole() )
-		{
-			return false;
-		}
-
 		var attackerPlayer = GameUtils.GetPlayerFromComponent( damageInfo.Attacker );
-		if ( !attackerPlayer.IsValid() || !attackerPlayer.Job.IsPoliceRole() )
+		if ( !attackerPlayer.IsValid() )
 		{
 			return false;
 		}
 
-		var multiplier = MathF.Max( 0f, Config.Current.Game.GovernanceMayorPoliceDamageMultiplier );
+		if ( Job.IsMayoralRole() && attackerPlayer.Job.IsPoliceRole() )
+		{
+			return ApplyDamageMultiplier( ref damageInfo, Config.Current.Game.GovernanceMayorPoliceDamageMultiplier );
+		}
+
+		if ( Job.IsPoliceRole() && attackerPlayer.Job.IsPoliceRole() )
+		{
+			return ApplyDamageMultiplier( ref damageInfo, Config.Current.Game.GovernancePoliceDamageMultiplier );
+		}
+
+		return false;
+	}
+
+	private static bool ApplyDamageMultiplier( ref DamageInfo damageInfo, float damageMultiplier )
+	{
+		var multiplier = MathF.Max( 0f, damageMultiplier );
 		if ( multiplier <= 0f )
 		{
 			DamageExtensions.ClearDamage( ref damageInfo );

--- a/game/Code/Player/Player.Health.cs
+++ b/game/Code/Player/Player.Health.cs
@@ -46,11 +46,44 @@ public partial class Player
 
 	void IDamageEvents.OnModifyDamageTaken( Component victim, ref DamageInfo damageInfo )
 	{
+		if ( ApplyMayorPoliceDamageMultiplier( ref damageInfo ) )
+		{
+			return;
+		}
+
 		var multiplier = Status.Current.ModifyDamageTaken( this );
 		if ( multiplier < 1f )
 		{
 			damageInfo = damageInfo with { Damage = damageInfo.Damage * multiplier };
 		}
+	}
+
+	private bool ApplyMayorPoliceDamageMultiplier( ref DamageInfo damageInfo )
+	{
+		if ( !Job.IsMayoralRole() )
+		{
+			return false;
+		}
+
+		var attackerPlayer = GameUtils.GetPlayerFromComponent( damageInfo.Attacker );
+		if ( !attackerPlayer.IsValid() || !attackerPlayer.Job.IsPoliceRole() )
+		{
+			return false;
+		}
+
+		var multiplier = MathF.Max( 0f, Config.Current.Game.GovernanceMayorPoliceDamageMultiplier );
+		if ( multiplier <= 0f )
+		{
+			DamageExtensions.ClearDamage( ref damageInfo );
+			return true;
+		}
+
+		if ( multiplier != 1f )
+		{
+			DamageExtensions.ScaleDamage( ref damageInfo, multiplier );
+		}
+
+		return false;
 	}
 
 	void IDamageEvents.OnDamageTakenHost( Component victim, DamageInfo damageInfo )


### PR DESCRIPTION
## Summary

Adds configurable governance damage multipliers to prevent police abuse around mayor and police friendly fire.

## Problem

Police players could directly damage or kill the mayor, which made it easy for bad actors to disrupt governance. A similar issue existed between police players, where friendly fire could be used to grief other officers.

- Applied these multipliers in the player damage pipeline before normal status damage modifiers.

## Notes

This only affects damage where the attacker resolves to a player with the police job tag. Indirect sources that do not resolve to the police player, such as certain entity explosions, are not blocked by this rule.