### PR TITLE
feat(construct): Multiline text construct

### DIFF
--- a/game/Code/Construct/ConstructDefinition.cs
+++ b/game/Code/Construct/ConstructDefinition.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Dxura.RP.Shared;
 namespace Dxura.RP.Game;
 
@@ -51,6 +52,8 @@ public abstract class ConstructDefinition<TConstruct, TData> : IConstructDefinit
 
 		return construct;
 	}
+
+	public virtual IConstructData? Migrate( uint fromVersion, JsonElement data, ConstructDataSerializer serializer ) => null;
 
 	protected virtual bool CanOwnerPlace( long owner ) => true;
 	protected abstract ConstructDataValidationResult ValidateTyped( TData data );

--- a/game/Code/Construct/Constructs/Text/Text.cs
+++ b/game/Code/Construct/Constructs/Text/Text.cs
@@ -22,10 +22,6 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 
 		GameObject.Name = $"Text ({lines[0].Text})";
 
-		// Disable the root renderer — all lines are rendered via child GameObjects
-		if ( TextRenderer.IsValid() )
-			TextRenderer.Enabled = false;
-
 		// Clean up previous line child objects
 		foreach ( var obj in _lineObjects )
 		{
@@ -37,14 +33,28 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 		// Only render lines with content — empty lines are invisible placeholders
 		var visibleLines = lines.Where( l => !string.IsNullOrEmpty( l.Text ) ).ToList();
 
+		// When all lines are empty show the prefab's default "Hello! ❤" as a placeholder
+		if ( visibleLines.Count == 0 )
+		{
+			if ( TextRenderer.IsValid() )
+			{
+				TextRenderer.Enabled = true;
+				TextRenderer.Scale = 0.1f;
+			}
+
+			const float fallbackFontSize = 32f;
+			const string fallbackText = "Hello! ❤";
+			( Collider as BoxCollider )!.Scale = new Vector3( 2f, fallbackText.Length * fallbackFontSize * 0.06f, fallbackFontSize * 0.1f );
+			return;
+		}
+
+		if ( TextRenderer.IsValid() )
+			TextRenderer.Enabled = false;
+
 		const float lineGap = 2f;
 		var lineHeights = visibleLines.Select( l => l.FontSize * 0.1f ).ToList();
-		float totalHeight = visibleLines.Count > 0
-			? lineHeights.Sum() + ( visibleLines.Count - 1 ) * lineGap
-			: 1f;
-		float maxWidth = visibleLines.Count > 0
-			? visibleLines.Max( l => MathF.Max( 1f, l.Text.Length * l.FontSize * 0.06f ) )
-			: 1f;
+		float totalHeight = lineHeights.Sum() + ( visibleLines.Count - 1 ) * lineGap;
+		float maxWidth = visibleLines.Max( l => MathF.Max( 1f, l.Text.Length * l.FontSize * 0.06f ) );
 
 		( Collider as BoxCollider )!.Scale = new Vector3( 2f, maxWidth, totalHeight );
 

--- a/game/Code/Construct/Constructs/Text/Text.cs
+++ b/game/Code/Construct/Constructs/Text/Text.cs
@@ -18,7 +18,7 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 	{
 		var textData = newData is TextData data ? data : new TextData();
 		var oldTextData = oldData is TextData old ? old : new TextData();
-		var lines = textData.Lines ?? new List<TextLineData> { new() };
+		var lines = textData.Lines is { Count: > 0 } l ? l : new List<TextLineData> { new() };
 
 		GameObject.Name = $"Text ({lines[0].Text})";
 
@@ -44,7 +44,7 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 
 			const float fallbackFontSize = 32f;
 			const string fallbackText = "Hello! ❤";
-			( Collider as BoxCollider )!.Scale = new Vector3( 2f, fallbackText.Length * fallbackFontSize * 0.06f, fallbackFontSize * 0.1f );
+			( Collider as BoxCollider )?.Scale = new Vector3( 2f, fallbackText.Length * fallbackFontSize * 0.06f, fallbackFontSize * 0.1f );
 			return;
 		}
 
@@ -56,7 +56,7 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 		float totalHeight = lineHeights.Sum() + ( visibleLines.Count - 1 ) * lineGap;
 		float maxWidth = visibleLines.Max( l => MathF.Max( 1f, l.Text.Length * l.FontSize * 0.06f ) );
 
-		( Collider as BoxCollider )!.Scale = new Vector3( 2f, maxWidth, totalHeight );
+		( Collider as BoxCollider )?.Scale = new Vector3( 2f, maxWidth, totalHeight );
 
 		float zOffset = totalHeight / 2f;
 

--- a/game/Code/Construct/Constructs/Text/Text.cs
+++ b/game/Code/Construct/Constructs/Text/Text.cs
@@ -16,8 +16,8 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 
 	protected override void OnDataChanged( IConstructData oldData, IConstructData newData )
 	{
-		var textData = newData is TextData data ? data : default;
-		var oldTextData = oldData is TextData old ? old : default;
+		var textData = newData is TextData data ? data : new TextData();
+		var oldTextData = oldData is TextData old ? old : new TextData();
 		var lines = textData.Lines ?? new List<TextLineData> { new() };
 
 		GameObject.Name = $"Text ({lines[0].Text})";

--- a/game/Code/Construct/Constructs/Text/Text.cs
+++ b/game/Code/Construct/Constructs/Text/Text.cs
@@ -1,4 +1,5 @@
 using Sandbox.Diagnostics;
+
 namespace Dxura.RP.Game;
 
 /// <summary>
@@ -11,52 +12,105 @@ public sealed class Text() : BaseConstruct( ConstructType.Text )
 	public required TextRenderer TextRenderer { get; set; }
 
 	private const string RedactedText = "#generic.redacted";
+	private readonly List<GameObject> _lineObjects = new();
 
 	protected override void OnDataChanged( IConstructData oldData, IConstructData newData )
 	{
 		var textData = newData is TextData data ? data : default;
 		var oldTextData = oldData is TextData old ? old : default;
+		var lines = textData.Lines ?? new List<TextLineData> { new() };
 
-		GameObject.Name = $"Text ({textData.Text})";
-		(Collider as BoxCollider)?.Scale = new Vector3( 2f, textData.Text.Length * textData.FontSize * 0.06f, textData.FontSize * 0.1f );
+		GameObject.Name = $"Text ({lines[0].Text})";
 
-		if ( !TextRenderer.IsValid() )
+		// Disable the root renderer — all lines are rendered via child GameObjects
+		if ( TextRenderer.IsValid() )
+			TextRenderer.Enabled = false;
+
+		// Clean up previous line child objects
+		foreach ( var obj in _lineObjects )
 		{
-			return;
+			if ( obj.IsValid() ) obj.Destroy();
 		}
 
-		TextRenderer.Enabled = true;
+		_lineObjects.Clear();
 
-		TextRenderer.Scale = 0.1f;
+		// Only render lines with content — empty lines are invisible placeholders
+		var visibleLines = lines.Where( l => !string.IsNullOrEmpty( l.Text ) ).ToList();
 
-		TextRenderer.TextScope = TextRenderer.TextScope with
+		const float lineGap = 2f;
+		var lineHeights = visibleLines.Select( l => l.FontSize * 0.1f ).ToList();
+		float totalHeight = visibleLines.Count > 0
+			? lineHeights.Sum() + ( visibleLines.Count - 1 ) * lineGap
+			: 1f;
+		float maxWidth = visibleLines.Count > 0
+			? visibleLines.Max( l => MathF.Max( 1f, l.Text.Length * l.FontSize * 0.06f ) )
+			: 1f;
+
+		( Collider as BoxCollider )!.Scale = new Vector3( 2f, maxWidth, totalHeight );
+
+		float zOffset = totalHeight / 2f;
+
+		for ( int i = 0; i < visibleLines.Count; i++ )
 		{
-			Text = textData.Text,
-			TextColor = textData.Color,
-			FontSize = textData.FontSize,
-			FontItalic = textData.Italic,
-			FontWeight = textData.FontWeight,
-			Outline = new TextRendering.Outline
-			{
-				Enabled = textData.Outline, Color = textData.OutlineColor, Size = textData.OutlineSize
-			}
-		};
+			var line = visibleLines[i];
+			float lineH = lineHeights[i];
+			float lineCenter = zOffset - lineH / 2f;
 
-		if ( Networking.IsHost && textData.Text != RedactedText && !IsPreview && textData.Text != oldTextData.Text )
-		{
-			var player = GameUtils.GetPlayerById( Owner );
-			var filtered = GameManager.ModerateText( player?.SteamId ?? 0, "TEXT", textData.Text );
+			var child = new GameObject();
+			child.Parent = GameObject;
+			child.Name = $"line_{i}";
+			child.LocalPosition = new Vector3( 0f, 0f, lineCenter );
+			_lineObjects.Add( child );
 
-			if ( filtered != textData.Text )
+			var renderer = child.AddComponent<TextRenderer>();
+			renderer.Enabled = true;
+			renderer.Scale = 0.1f;
+			renderer.TextScope = renderer.TextScope with
 			{
-				// Use internal serialization for special redacted text case
-				var serializationResult = Construct.Current.Serializer.Serialize( ConstructType.Text, new TextData
+				Text = line.Text,
+				TextColor = line.Color,
+				FontSize = line.FontSize,
+				FontItalic = line.Italic,
+				FontWeight = line.FontWeight,
+				Outline = new TextRendering.Outline
 				{
-					Text = RedactedText, Color = Color.Red, FontSize = 60
-				} );
-				
-				BroadcastData( serializationResult.IsSuccess ? serializationResult.Value : string.Empty );
-			}
+					Enabled = line.Outline, Color = line.OutlineColor, Size = line.OutlineSize
+				}
+			};
+
+			zOffset -= lineH + lineGap;
 		}
+
+		if ( Networking.IsHost && !IsPreview )
+		{
+			ModerateLines( lines, oldTextData.Lines ?? new List<TextLineData>() );
+		}
+	}
+
+	private void ModerateLines( List<TextLineData> lines, List<TextLineData> oldLines )
+	{
+		var player = GameUtils.GetPlayerById( Owner );
+		var moderatedLines = new List<TextLineData>( lines );
+		bool anyModerated = false;
+
+		for ( int i = 0; i < lines.Count; i++ )
+		{
+			var line = lines[i];
+			if ( string.IsNullOrEmpty( line.Text ) || line.Text == RedactedText ) continue;
+
+			var oldText = i < oldLines.Count ? oldLines[i].Text : null;
+			if ( line.Text == oldText ) continue;
+
+			var filtered = GameManager.ModerateText( player?.SteamId ?? 0, "TEXT", line.Text );
+			if ( filtered == line.Text ) continue;
+
+			moderatedLines[i] = new TextLineData { Text = RedactedText, Color = Color.Red, FontSize = 60 };
+			anyModerated = true;
+		}
+
+		if ( !anyModerated ) return;
+
+		var serResult = Construct.Current.Serializer.Serialize( ConstructType.Text, new TextData { Lines = moderatedLines } );
+		BroadcastData( serResult.IsSuccess ? serResult.Value : string.Empty );
 	}
 }

--- a/game/Code/Construct/Constructs/Text/TextData.cs
+++ b/game/Code/Construct/Constructs/Text/TextData.cs
@@ -1,18 +1,7 @@
-﻿namespace Dxura.RP.Game;
+namespace Dxura.RP.Game;
 
 public struct TextData() : IConstructData
 {
-	public readonly uint SchemaVersion => 1;
-
-	public string Text { get; set; } = "";
-	public float FontSize { get; set; } = 100f;
-	public Color Color { get; set; } = Color.White;
-
-	public bool Italic { get; set; } = false;
-
-	public int FontWeight { get; set; } = 400;
-
-	public bool Outline { get; set; } = false;
-	public Color OutlineColor { get; set; } = Color.Black;
-	public float OutlineSize { get; set; } = 5f;
+	public readonly uint SchemaVersion => 2;
+	public List<TextLineData> Lines { get; set; } = new List<TextLineData> { new TextLineData() };
 }

--- a/game/Code/Construct/Constructs/Text/TextDefinition.cs
+++ b/game/Code/Construct/Constructs/Text/TextDefinition.cs
@@ -1,9 +1,12 @@
-﻿namespace Dxura.RP.Game;
+using System.Text.Json;
+
+namespace Dxura.RP.Game;
 
 public class TextDefinition : ConstructDefinition<Text, TextData>
 {
 	public override ConstructType Type => ConstructType.Text;
 	public override uint Limit => Config.Current.Game.TextLimit;
+	public override uint DataSchemaVersion => 2;
 
 	public const uint MinTextLength = 1;
 	public const uint MaxTextLength = 150;
@@ -13,64 +16,93 @@ public class TextDefinition : ConstructDefinition<Text, TextData>
 	public const uint MaxOutlineSize = 20;
 	public const uint MinFontWeight = 100;
 	public const uint MaxFontWeight = 800;
+	public const uint MinLines = 1;
+	public const uint MaxLines = 4;
 
+	public override IConstructData? Migrate( uint fromVersion, JsonElement data, ConstructDataSerializer serializer )
+	{
+		if ( fromVersion == 1 )
+		{
+			var line = new TextLineData();
+
+			if ( data.TryGetProperty( "text", out var t ) ) line.Text = t.GetString() ?? "";
+			if ( data.TryGetProperty( "fontSize", out var f ) ) line.FontSize = f.GetSingle();
+			if ( data.TryGetProperty( "italic", out var it ) ) line.Italic = it.GetBoolean();
+			if ( data.TryGetProperty( "fontWeight", out var fw ) ) line.FontWeight = fw.GetInt32();
+			if ( data.TryGetProperty( "outline", out var o ) ) line.Outline = o.GetBoolean();
+			if ( data.TryGetProperty( "outlineSize", out var os ) ) line.OutlineSize = os.GetSingle();
+			line.Color = ParseColor( data, "color", Color.White );
+			line.OutlineColor = ParseColor( data, "outlineColor", Color.Black );
+
+			return new TextData { Lines = new List<TextLineData> { line } };
+		}
+
+		return null;
+	}
+
+	private static Color ParseColor( JsonElement data, string propertyName, Color fallback )
+	{
+		if ( !data.TryGetProperty( propertyName, out var colorEl ) ) return fallback;
+
+		float r = colorEl.TryGetProperty( "r", out var ri ) ? ri.GetSingle() : fallback.r;
+		float g = colorEl.TryGetProperty( "g", out var gi ) ? gi.GetSingle() : fallback.g;
+		float b = colorEl.TryGetProperty( "b", out var bi ) ? bi.GetSingle() : fallback.b;
+		float a = colorEl.TryGetProperty( "a", out var ai ) ? ai.GetSingle() : fallback.a;
+
+		return new Color( r, g, b, a );
+	}
 
 	protected override ConstructDataValidationResult ValidateTyped( TextData data )
 	{
-		if ( string.IsNullOrEmpty( data.Text ) )
+		var lines = data.Lines;
+
+		if ( lines == null || lines.Count < MinLines )
+			return ConstructDataValidationResult.Failure( "At least one text line is required" );
+
+		if ( lines.Count > MaxLines )
+			return ConstructDataValidationResult.Failure( $"Maximum {MaxLines} text lines allowed" );
+
+		// Empty lines are allowed — they are simply skipped at render time.
+		// Only validate lines that have content.
+		bool hasContent = false;
+
+		foreach ( var line in lines )
 		{
-			return ConstructDataValidationResult.Failure( "Text cannot be empty" );
+			if ( string.IsNullOrEmpty( line.Text ) ) continue;
+
+			hasContent = true;
+
+			if ( line.Text.Length > MaxTextLength )
+				return ConstructDataValidationResult.Failure( $"Text exceeds maximum of {MaxTextLength} characters" );
+
+			if ( line.FontSize < MinFontSize )
+				return ConstructDataValidationResult.Failure( $"Font size must be at least {MinFontSize}" );
+
+			if ( line.FontSize > MaxFontSize )
+				return ConstructDataValidationResult.Failure( $"Font size exceeds maximum of {MaxFontSize}" );
+
+			if ( line.OutlineSize < MinOutlineSize )
+				return ConstructDataValidationResult.Failure( $"Outline size must be at least {MinOutlineSize}" );
+
+			if ( line.OutlineSize > MaxOutlineSize )
+				return ConstructDataValidationResult.Failure( $"Outline size exceeds maximum of {MaxOutlineSize}" );
+
+			if ( line.FontWeight < MinFontWeight )
+				return ConstructDataValidationResult.Failure( $"Font weight must be at least {MinFontWeight}" );
+
+			if ( line.FontWeight > MaxFontWeight )
+				return ConstructDataValidationResult.Failure( $"Font weight exceeds maximum of {MaxFontWeight}" );
 		}
 
-		if ( data.Text.Length < MinTextLength )
-		{
-			return ConstructDataValidationResult.Failure( $"Text must be greater than {MinTextLength} characters" );
-		}
-
-		if ( data.Text.Length > MaxTextLength )
-		{
-			return ConstructDataValidationResult.Failure( $"Text exceeds maximum length of {MaxTextLength} characters" );
-		}
-
-		if ( data.FontSize < MinFontSize )
-		{
-			return ConstructDataValidationResult.Failure( $"Font size must be greater than {MinFontSize}" );
-		}
-
-		if ( data.FontSize > MaxFontSize )
-		{
-			return ConstructDataValidationResult.Failure( $"Font size exceeds maximum of {MaxFontSize}" );
-		}
-
-		if ( data.OutlineSize < MinOutlineSize )
-		{
-			return ConstructDataValidationResult.Failure( $"Outline size must be greater than {MinOutlineSize}" );
-		}
-
-		if ( data.OutlineSize > MaxOutlineSize )
-		{
-			return ConstructDataValidationResult.Failure( $"Outline size exceed maximum of  {MinOutlineSize}" );
-		}
-
-		if ( data.FontWeight < MinFontWeight )
-		{
-			return ConstructDataValidationResult.Failure( $"Font weight must be greater than {MinFontWeight}" );
-		}
-
-		if ( data.FontWeight > MaxFontWeight )
-		{
-			return ConstructDataValidationResult.Failure( $"Font weight exceed maximum of  {MaxFontSize}" );
-		}
-
+		if ( !hasContent )
+			return ConstructDataValidationResult.Failure( "At least one line must have text" );
 
 		return ConstructDataValidationResult.Success();
 	}
 
 	protected override GameObject CreateConstructInternal( TextData data, Vector3 position, Rotation rotation )
 	{
-		var textGameObject = GameObject.GetPrefab( "prefabs/constructs/text.prefab" ).Clone( position, rotation );
-
-		return textGameObject;
+		return GameObject.GetPrefab( "prefabs/constructs/text.prefab" ).Clone( position, rotation );
 	}
 
 	protected override bool CanOwnerPlace( long owner )

--- a/game/Code/Construct/Constructs/Text/TextDefinition.cs
+++ b/game/Code/Construct/Constructs/Text/TextDefinition.cs
@@ -61,6 +61,9 @@ public class TextDefinition : ConstructDefinition<Text, TextData>
 
 		if ( lines.Count > MaxLines )
 			return ConstructDataValidationResult.Failure( $"Maximum {MaxLines} text lines allowed" );
+		
+		if ( lines.TrueForAll( l => string.IsNullOrEmpty( l.Text ) ) )
+ 			return ConstructDataValidationResult.Failure( "At least one line must have text" );
 
 		// Empty lines are allowed — they are skipped at render time and show the "Hello! ❤" fallback.
 		foreach ( var line in lines )

--- a/game/Code/Construct/Constructs/Text/TextDefinition.cs
+++ b/game/Code/Construct/Constructs/Text/TextDefinition.cs
@@ -62,15 +62,10 @@ public class TextDefinition : ConstructDefinition<Text, TextData>
 		if ( lines.Count > MaxLines )
 			return ConstructDataValidationResult.Failure( $"Maximum {MaxLines} text lines allowed" );
 
-		// Empty lines are allowed — they are simply skipped at render time.
-		// Only validate lines that have content.
-		bool hasContent = false;
-
+		// Empty lines are allowed — they are skipped at render time and show the "Hello! ❤" fallback.
 		foreach ( var line in lines )
 		{
 			if ( string.IsNullOrEmpty( line.Text ) ) continue;
-
-			hasContent = true;
 
 			if ( line.Text.Length > MaxTextLength )
 				return ConstructDataValidationResult.Failure( $"Text exceeds maximum of {MaxTextLength} characters" );
@@ -93,9 +88,6 @@ public class TextDefinition : ConstructDefinition<Text, TextData>
 			if ( line.FontWeight > MaxFontWeight )
 				return ConstructDataValidationResult.Failure( $"Font weight exceeds maximum of {MaxFontWeight}" );
 		}
-
-		if ( !hasContent )
-			return ConstructDataValidationResult.Failure( "At least one line must have text" );
 
 		return ConstructDataValidationResult.Success();
 	}

--- a/game/Code/Construct/Constructs/Text/TextLineData.cs
+++ b/game/Code/Construct/Constructs/Text/TextLineData.cs
@@ -1,0 +1,13 @@
+namespace Dxura.RP.Game;
+
+public struct TextLineData()
+{
+	public string Text { get; set; } = "";
+	public float FontSize { get; set; } = 100f;
+	public Color Color { get; set; } = Color.White;
+	public bool Italic { get; set; } = false;
+	public int FontWeight { get; set; } = 400;
+	public bool Outline { get; set; } = false;
+	public Color OutlineColor { get; set; } = Color.Black;
+	public float OutlineSize { get; set; } = 5f;
+}

--- a/game/Code/Construct/Constructs/Text/TextLineProxy.cs
+++ b/game/Code/Construct/Constructs/Text/TextLineProxy.cs
@@ -1,9 +1,5 @@
 namespace Dxura.RP.Game.Tools;
 
-/// <summary>
-/// Helper class with [Property] attributes for each TextLineData field.
-/// Used by TextToolInspector to render per-line controls via TypeLibrary.GetSerializedObject.
-/// </summary>
 public class TextLineProxy( TextTool tool, int index )
 {
 	[Property]
@@ -43,6 +39,7 @@ public class TextLineProxy( TextTool tool, int index )
 	[Property]
 	[Title( "Font Weight" )]
 	[Range( TextDefinition.MinFontWeight, TextDefinition.MaxFontWeight )]
+	[Step( 100 )]
 	public int FontWeight
 	{
 		get => tool.GetLine( index ).FontWeight;

--- a/game/Code/Construct/Constructs/Text/TextLineProxy.cs
+++ b/game/Code/Construct/Constructs/Text/TextLineProxy.cs
@@ -1,0 +1,77 @@
+namespace Dxura.RP.Game.Tools;
+
+/// <summary>
+/// Helper class with [Property] attributes for each TextLineData field.
+/// Used by TextToolInspector to render per-line controls via TypeLibrary.GetSerializedObject.
+/// </summary>
+public class TextLineProxy( TextTool tool, int index )
+{
+	[Property]
+	[Title( "Text" )]
+	[Range( TextDefinition.MinTextLength, TextDefinition.MaxTextLength )]
+	public string Text
+	{
+		get => tool.GetLine( index ).Text;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { Text = value } );
+	}
+
+	[Property]
+	[Title( "Size" )]
+	[Range( TextDefinition.MinFontSize, TextDefinition.MaxFontSize )]
+	public float Size
+	{
+		get => tool.GetLine( index ).FontSize;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { FontSize = value } );
+	}
+
+	[Property]
+	[Title( "Color" )]
+	public Color Color
+	{
+		get => tool.GetLine( index ).Color;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { Color = value } );
+	}
+
+	[Property]
+	[Title( "Italic" )]
+	public bool Italic
+	{
+		get => tool.GetLine( index ).Italic;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { Italic = value } );
+	}
+
+	[Property]
+	[Title( "Font Weight" )]
+	[Range( TextDefinition.MinFontWeight, TextDefinition.MaxFontWeight )]
+	public int FontWeight
+	{
+		get => tool.GetLine( index ).FontWeight;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { FontWeight = value } );
+	}
+
+	[Property]
+	[Title( "Outline" )]
+	public bool Outline
+	{
+		get => tool.GetLine( index ).Outline;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { Outline = value } );
+	}
+
+	[Property]
+	[Title( "Outline Color" )]
+	public Color OutlineColor
+	{
+		get => tool.GetLine( index ).OutlineColor;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { OutlineColor = value } );
+	}
+
+	[Property]
+	[Title( "Outline Size" )]
+	[Range( TextDefinition.MinOutlineSize, TextDefinition.MaxOutlineSize )]
+	[Step( 1 )]
+	public float OutlineSize
+	{
+		get => tool.GetLine( index ).OutlineSize;
+		set => tool.UpdateLine( index, tool.GetLine( index ) with { OutlineSize = value } );
+	}
+}

--- a/game/Code/Construct/Constructs/Text/TextTool.cs
+++ b/game/Code/Construct/Constructs/Text/TextTool.cs
@@ -68,4 +68,15 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 		Data = new TextData();
 		_proxies.Clear();
 	}
+
+	public override void PrimaryUseStart()
+	{
+		if ( Lines.All( l => string.IsNullOrEmpty( l.Text ) ) )
+		{
+			Notify.Error( "#notify.construct.text_empty" );
+			return;
+		}
+
+		base.PrimaryUseStart();
+	}
 }

--- a/game/Code/Construct/Constructs/Text/TextTool.cs
+++ b/game/Code/Construct/Constructs/Text/TextTool.cs
@@ -5,6 +5,8 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 {
 	protected override bool FlatSurface => true;
 
+	private readonly List<TextLineProxy> _proxies = new();
+
 	protected override TextData GetPreviewDisplayData()
 	{
 		if ( !string.IsNullOrEmpty( Data.Text ) ) return Data;
@@ -12,96 +14,58 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 		return Data with { Text = string.Format( Language.GetPhrase( "tool.text.preview_placeholder" ), key ) };
 	}
 
-	[Property]
-	[Title( "Text" )]
-	[Range( TextDefinition.MinTextLength, TextDefinition.MaxTextLength )]
-	public string Text
+	public int SelectedLine { get; set; } = 0;
+
+	public List<TextLineData> Lines => Data.Lines ?? new List<TextLineData> { new() };
+	public int LineCount => Lines.Count;
+
+	public TextLineData GetLine( int index )
 	{
-		get => Data.Text;
-		set => Data = Data with
-		{
-			Text = value
-		};
+		var lines = Lines;
+		return index >= 0 && index < lines.Count ? lines[index] : new TextLineData();
 	}
 
-	[Property]
-	[Title( "Size" )]
-	[Range( TextDefinition.MinFontSize, TextDefinition.MaxFontSize )]
-	public float Size
+	public void UpdateLine( int index, TextLineData line )
 	{
-		get => Data.FontSize;
-		set => Data = Data with
+		var newLines = new List<TextLineData>( Lines );
+		if ( index >= 0 && index < newLines.Count )
 		{
-			FontSize = value
-		};
+			newLines[index] = line;
+			Data = Data with { Lines = newLines };
+		}
 	}
 
-	[Property]
-	[Title( "Color" )]
-	public Color Color
+	public void AddLine()
 	{
-		get => Data.Color;
-		set => Data = Data with
-		{
-			Color = value
-		};
+		if ( LineCount >= TextDefinition.MaxLines ) return;
+
+		var newLines = new List<TextLineData>( Lines ) { new TextLineData() };
+		Data = Data with { Lines = newLines };
+		_proxies.Add( new TextLineProxy( this, _proxies.Count ) );
 	}
 
-	[Property]
-	[Title( "Italic" )]
-	public bool Italic
+	public void RemoveLine( int index )
 	{
-		get => Data.Italic;
-		set => Data = Data with
-		{
-			Italic = value
-		};
+		if ( LineCount <= 1 || index < 0 || index >= LineCount ) return;
+
+		var newLines = new List<TextLineData>( Lines );
+		newLines.RemoveAt( index );
+		Data = Data with { Lines = newLines };
+
+		if ( _proxies.Count > 0 )
+			_proxies.RemoveAt( _proxies.Count - 1 );
 	}
 
-	[Property]
-	[Title( "Font Weight" )]
-	[Range( TextDefinition.MinFontWeight, TextDefinition.MaxFontWeight )]
-	public int FontWeight
+	public TextLineProxy GetLineProxy( int index )
 	{
-		get => Data.FontWeight;
-		set => Data = Data with
-		{
-			FontWeight = value
-		};
+		while ( _proxies.Count <= index )
+			_proxies.Add( new TextLineProxy( this, _proxies.Count ) );
+		return _proxies[index];
 	}
 
-	[Property]
-	[Title( "Outline" )]
-	public bool Outline
+	public void ResetLines()
 	{
-		get => Data.Outline;
-		set => Data = Data with
-		{
-			Outline = value
-		};
-	}
-
-	[Property]
-	[Title( "Outline Color" )]
-	public Color OutlineColor
-	{
-		get => Data.OutlineColor;
-		set => Data = Data with
-		{
-			OutlineColor = value
-		};
-	}
-
-	[Property]
-	[Title( "Outline Size" )]
-	[Range( TextDefinition.MinOutlineSize, TextDefinition.MaxOutlineSize )]
-	[Step( 1 )]
-	public float OutlineSize
-	{
-		get => Data.OutlineSize;
-		set => Data = Data with
-		{
-			OutlineSize = value
-		};
+		Data = new TextData();
+		_proxies.Clear();
 	}
 }

--- a/game/Code/Construct/Constructs/Text/TextTool.cs
+++ b/game/Code/Construct/Constructs/Text/TextTool.cs
@@ -41,7 +41,6 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 
 		var newLines = new List<TextLineData>( Lines ) { new TextLineData() };
 		Data = Data with { Lines = newLines };
-		_proxies.Add( new TextLineProxy( this, _proxies.Count ) );
 	}
 
 	public void RemoveLine( int index )
@@ -51,9 +50,7 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 		var newLines = new List<TextLineData>( Lines );
 		newLines.RemoveAt( index );
 		Data = Data with { Lines = newLines };
-
-		if ( _proxies.Count > 0 )
-			_proxies.RemoveAt( _proxies.Count - 1 );
+		_proxies.Clear();
 	}
 
 	public TextLineProxy GetLineProxy( int index )

--- a/game/Code/Construct/Constructs/Text/TextTool.cs
+++ b/game/Code/Construct/Constructs/Text/TextTool.cs
@@ -9,9 +9,21 @@ public class TextTool() : BaseConstructTool<TextData>( ConstructType.Text )
 
 	protected override TextData GetPreviewDisplayData()
 	{
-		if ( !string.IsNullOrEmpty( Data.Text ) ) return Data;
+		var lines = Lines;
+		if ( lines.Any( l => !string.IsNullOrEmpty( l.Text ) ) ) return Data;
+
 		var key = Input.GetButtonOrigin( "BuildMenu" );
-		return Data with { Text = string.Format( Language.GetPhrase( "tool.text.preview_placeholder" ), key ) };
+		var previewLines = new List<TextLineData>( lines );
+
+		if ( previewLines.Count == 0 )
+			previewLines.Add( new TextLineData() );
+
+		previewLines[0] = previewLines[0] with
+		{
+			Text = string.Format( Language.GetPhrase( "tool.text.preview_placeholder" ), key )
+		};
+
+		return Data with { Lines = previewLines };
 	}
 
 	public int SelectedLine { get; set; } = 0;

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
@@ -1,0 +1,191 @@
+@inherits Panel
+@using Dxura.RP.Game.Equipments
+@using Dxura.RP.Game.Tools
+@using Sandbox.UI
+@implements IToolInspector
+@namespace Dxura.RP.Game.UI
+@attribute [StyleSheet]
+@attribute [ToolInspector( typeof(TextTool) )]
+
+<root>
+
+	@if ( ToolEquipment == null || ToolEquipment.CurrentTool is not TextTool textTool ) return;
+
+	<label class="header">@textTool.GetName()</label>
+
+	<div class="tabs">
+		@foreach ( var idx in Enumerable.Range( 0, textTool.LineCount ) )
+		{
+			var i = idx;
+			<div class="tab-btn @( textTool.SelectedLine == i ? "active" : "" )"
+			     @onclick="@(() => SelectLine( textTool, i ))">
+				Line @( i + 1 )
+			</div>
+		}
+		<div style="flex: 1;"></div>
+		<div class="tab-action @( textTool.LineCount >= TextDefinition.MaxLines ? "disabled" : "" )"
+		     @onclick="@(() => AddLine( textTool ))">
+			+
+		</div>
+		<div class="tab-action danger @( textTool.LineCount <= 1 ? "disabled" : "" )"
+		     @onclick="@(() => RemoveSelectedLine( textTool ))">
+			−
+		</div>
+	</div>
+
+	<div class="content" style="padding-bottom: 60px;">
+		@{
+			var proxy = textTool.GetLineProxy( textTool.SelectedLine );
+		}
+		<div class="controls">
+			@foreach ( var property in TypeLibrary.GetSerializedObject( proxy ) )
+			{
+				if ( !property.HasAttribute<PropertyAttribute>() ) continue;
+				property.TryGetAttribute<TitleAttribute>( out var title );
+				var name = title?.Value ?? property.Name;
+
+				@if ( property.PropertyType == typeof(float) )
+				{
+					<div class="control control-column">
+						<div class="control-label-top">
+							<p>@( name )</p>
+						</div>
+						@{
+							property.TryGetAttribute<RangeAttribute>( out var range );
+							property.TryGetAttribute<StepAttribute>( out var step );
+						}
+						<div class="control-input-row">
+							<SliderControl Min=@( range?.Min ?? 0 ) Max=@( range?.Max ?? 1 ) Step=@( step?.Step ?? 0.01f )
+							               Value="@( property.GetValue<float>() )"
+							               OnValueChanged=@( ( float value ) => { property.SetValue( value ); } )
+							               ShowTextEntry=@( false )
+							               style="flex: 1; min-width: 50px;" />
+							<TextEntry
+								Value="@( property.GetValue<float>().ToString("F2") )"
+								class="text-tertiary"
+								style="width: 60px; flex-shrink: 0;"
+								OnTextEdited=@( ( string value ) => {
+									if ( float.TryParse( value, out var floatValue ) )
+									{
+										if ( range != null ) floatValue = Math.Clamp( floatValue, range.Min, range.Max );
+										property.SetValue( floatValue );
+									}
+								} ) />
+						</div>
+					</div>
+				}
+				else if ( property.PropertyType == typeof(int) )
+				{
+					<div class="control control-column">
+						<div class="control-label-top">
+							<p>@( name )</p>
+						</div>
+						@{
+							property.TryGetAttribute<RangeAttribute>( out var range );
+							property.TryGetAttribute<StepAttribute>( out var step );
+						}
+						<div class="control-input-row">
+							<SliderControl Min=@( range?.Min ?? 0 ) Max=@( range?.Max ?? 1 ) Step=@( step?.Step ?? 0.01f )
+							               Value="@( property.GetValue<int>() )"
+							               OnValueChanged=@( ( float value ) => { property.SetValue( (int)value ); } )
+							               ShowTextEntry=@( false )
+							               style="flex: 1; min-width: 50px;" />
+							<TextEntry
+								Value="@( property.GetValue<int>().ToString() )"
+								class="text-tertiary"
+								style="width: 60px; flex-shrink: 0;"
+								OnTextEdited=@( ( string value ) => {
+									if ( int.TryParse( value, out var intValue ) )
+									{
+										if ( range != null ) intValue = Math.Clamp( intValue, (int)range.Min, (int)range.Max );
+										property.SetValue( intValue );
+									}
+								} ) />
+						</div>
+					</div>
+				}
+				else if ( property.PropertyType == typeof(bool) )
+				{
+					<div class="control control-inline">
+						<div class="control-label-inline">
+							<p>@( name )</p><span class="colon">:</span>
+						</div>
+						<div class="control-input-inline">
+							<SwitchControl Value="@( property.GetValue<bool>() )" OnValueChanged=@( ( bool _value ) => { property.SetValue( _value ); } ) />
+						</div>
+					</div>
+				}
+				else if ( property.PropertyType == typeof(Color) )
+				{
+					<div class="control control-inline">
+						<div class="control-label-inline">
+							<p>@( name )</p><span class="colon">:</span>
+						</div>
+						<div class="control-input-inline">
+							<ColorControl Property=@property />
+						</div>
+					</div>
+				}
+				else if ( property.PropertyType == typeof(string) )
+				{
+					<div class="control control-column">
+						<div class="control-label-top">
+							<p>@( name )</p>
+						</div>
+						@{
+							property.TryGetAttribute<RangeAttribute>( out var range );
+						}
+						<div class="control-input-full">
+							<TextEntry class="text-tertiary"
+							           style="width: 100%;"
+							           MaxLength="@( range?.Max.CeilToInt() ?? Config.Current.Game.DefaultTextEntryMaxLength )"
+							           Value="@( property.GetValue<string>() )"
+							           OnTextEdited=@( ( string value ) => { property.SetValue( value ); } ) />
+						</div>
+					</div>
+				}
+			}
+		</div>
+	</div>
+
+	<div class="bottom-actions">
+		<button class="btn btn-secondary" style="width: 200px;"
+		        @onclick="@(() => { textTool.ResetLines(); textTool.SelectedLine = 0; ToolMenu.Instance?.UpdateInspector(); })">
+			<span>#tool.inspector.reset_settings</span>
+		</button>
+	</div>
+
+</root>
+
+@code
+{
+	public ToolEquipment? ToolEquipment { get; set; }
+
+	protected override int BuildHash()
+	{
+		return ( ToolEquipment?.CurrentTool as TextTool )?.LineCount ?? 0;
+	}
+
+	private void SelectLine( TextTool tool, int index )
+	{
+		tool.SelectedLine = index;
+		ToolMenu.Instance?.UpdateInspector();
+	}
+
+	private void AddLine( TextTool tool )
+	{
+		if ( tool.LineCount >= TextDefinition.MaxLines ) return;
+		tool.AddLine();
+		tool.SelectedLine = tool.LineCount - 1;
+		ToolMenu.Instance?.UpdateInspector();
+	}
+
+	private void RemoveSelectedLine( TextTool tool )
+	{
+		if ( tool.LineCount <= 1 ) return;
+		tool.RemoveLine( tool.SelectedLine );
+		if ( tool.SelectedLine >= tool.LineCount )
+			tool.SelectedLine = tool.LineCount - 1;
+		ToolMenu.Instance?.UpdateInspector();
+	}
+}

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
@@ -14,22 +14,25 @@
 	<label class="header">@textTool.GetName()</label>
 
 	<div class="tabs">
-		@foreach ( var idx in Enumerable.Range( 0, textTool.LineCount ) )
-		{
-			var i = idx;
-			<div class="tab-btn @( textTool.SelectedLine == i ? "active" : "" )"
-			     @onclick="@(() => SelectLine( textTool, i ))">
-				Line @( i + 1 )
-			</div>
-		}
-		<div style="flex: 1;"></div>
-		<div class="tab-action @( textTool.LineCount >= TextDefinition.MaxLines ? "disabled" : "" )"
-		     @onclick="@(() => AddLine( textTool ))">
-			+
+		<div class="line-tabs">
+			@foreach ( var idx in Enumerable.Range( 0, textTool.LineCount ) )
+			{
+				var i = idx;
+				<div class="tab-btn @( textTool.SelectedLine == i ? "active" : "" )"
+				     @onclick="@(() => SelectLine( textTool, i ))">
+					@string.Format( Language.GetPhrase( "tool.inspector.line" ), i + 1 )
+				</div>
+			}
 		</div>
-		<div class="tab-action danger @( textTool.LineCount <= 1 ? "disabled" : "" )"
-		     @onclick="@(() => RemoveSelectedLine( textTool ))">
-			−
+		<div class="tab-actions">
+			<div class="tab-action @( textTool.LineCount >= TextDefinition.MaxLines ? "disabled" : "" )"
+			     @onclick="@(() => AddLine( textTool ))">
+				+
+			</div>
+			<div class="tab-action danger @( textTool.LineCount <= 1 ? "disabled" : "" )"
+			     @onclick="@(() => RemoveSelectedLine( textTool ))">
+				−
+			</div>
 		</div>
 	</div>
 

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor
@@ -163,7 +163,8 @@
 
 	protected override int BuildHash()
 	{
-		return ( ToolEquipment?.CurrentTool as TextTool )?.LineCount ?? 0;
+		var tool = ToolEquipment?.CurrentTool as TextTool;
+		return HashCode.Combine( tool?.LineCount ?? 0, tool?.SelectedLine ?? 0 );
 	}
 
 	private void SelectLine( TextTool tool, int index )

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor.scss
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor.scss
@@ -9,15 +9,41 @@ TextToolInspector {
   font-size: 13px;
 
   .tabs {
+    display: flex;
     flex-direction: row;
     align-items: center;
+    width: 100%;
     padding: $space-2 $space-3;
     gap: 6px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
+    min-width: 0;
+  }
+
+  .line-tabs {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    flex: 1 1 auto;
+    width: 0;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+  }
+
+  .tab-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
   }
 
   .tab-btn {
+    display: flex;
+    align-items: center;
     padding: 5px $space-2;
     background-color: rgba(255, 255, 255, 0.04);
     border-radius: 5px;
@@ -46,12 +72,14 @@ TextToolInspector {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 5px;
     cursor: pointer;
+    display: flex;
     align-items: center;
     justify-content: center;
     font-size: 16px;
     font-weight: 400;
     color: rgba(255, 255, 255, 0.7);
     flex-shrink: 0;
+    line-height: 1;
 
     &:hover {
       background-color: rgba(255, 255, 255, 0.12);

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor.scss
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/TextToolInspector.razor.scss
@@ -1,0 +1,177 @@
+@import "../../../../../styles.scss";
+
+TextToolInspector {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  font-family: Poppins;
+  font-size: 13px;
+
+  .tabs {
+    flex-direction: row;
+    align-items: center;
+    padding: $space-2 $space-3;
+    gap: 6px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    flex-shrink: 0;
+  }
+
+  .tab-btn {
+    padding: 5px $space-2;
+    background-color: rgba(255, 255, 255, 0.04);
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: $text-xs;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.55);
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    &.active {
+      background-color: $color-accent;
+      color: white;
+      font-weight: 600;
+    }
+  }
+
+  .tab-action {
+    width: 26px;
+    height: 26px;
+    background-color: rgba(255, 255, 255, 0.06);
+    border-radius: 5px;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.7);
+    flex-shrink: 0;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.12);
+      color: white;
+    }
+
+    &.danger:hover {
+      background-color: rgba($color-bad, 0.35);
+      color: white;
+    }
+
+    &.disabled {
+      opacity: 0.25;
+      pointer-events: none;
+    }
+  }
+
+  > .content {
+    flex: 1;
+    flex-direction: column;
+    overflow-y: scroll;
+    min-height: 0;
+
+    > .controls {
+      flex-direction: column;
+      padding: $space-2 $space-3;
+      gap: 6px;
+
+      > .control {
+        &.control-column {
+          display: flex;
+          flex-direction: column;
+
+          .control-label-top {
+            display: flex;
+            align-items: center;
+            font-weight: 500;
+
+            p {
+              margin: 0;
+              color: #ffffff;
+            }
+          }
+
+          .control-input-row {
+            display: flex;
+            align-items: center;
+
+            SliderControl {
+              flex: 1;
+              min-width: 100px;
+            }
+
+            TextEntry {
+              flex-shrink: 0;
+            }
+          }
+
+          .control-input-full {
+            display: flex;
+            width: 100%;
+
+            TextEntry {
+              width: 100%;
+            }
+          }
+
+          .control-input-row TextEntry,
+          .control-input-full TextEntry {
+            margin-top: 4px;
+            min-height: 28px;
+            height: 28px;
+            background-color: $color-secondary;
+
+            .content-label,
+            .inner {
+              background-color: $color-secondary;
+              padding: 2px 6px;
+            }
+          }
+        }
+
+        &.control-inline {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+
+          .control-label-inline {
+            display: flex;
+            align-items: center;
+            min-width: 120px;
+            flex-shrink: 0;
+
+            p {
+              margin: 0;
+              white-space: nowrap;
+              color: #ffffff;
+            }
+
+            .colon {
+              margin-left: 4px;
+            }
+          }
+
+          .control-input-inline {
+            display: flex;
+            align-items: center;
+            flex: 1;
+          }
+        }
+      }
+    }
+  }
+
+  .bottom-actions {
+    position: absolute;
+    bottom: 10px;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -859,6 +859,7 @@
   "tool.inspector.material_selected": "Material Selected",
   "tool.inspector.reset_settings": "Reset Settings",
   "tool.inspector.text_placeholder": "Enter text...",
+  "tool.inspector.line": "Line {0}",
   "roleplay.job.citizen.name": "Citizen",
   "roleplay.job.citizen.description": "An ordinary member of society with no specialized role.",
   "roleplay.job.cook.name": "Cook",

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -1015,6 +1015,7 @@
   "notify.construct.not_found": "Could not find construct",
   "notify.construct.limit": "You have reached your limit",
   "notify.construct.blocked_by_player": "Spawn blocked by player in the area",
+  "notify.construct.text_empty": "At least one line must have text",
   "notify.stacker.invalid_count": "Invalid stack count",
   "notify.stacker.invalid_offset": "Invalid stack offset",
   "notify.stacker.invalid_target": "You must target a valid prop to stack",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -769,6 +769,7 @@
   "tool.inspector.material_selected": "Matériau sélectionné",
   "tool.inspector.reset_settings": "Réinitialiser les paramètres",
   "tool.inspector.text_placeholder": "Saisir du texte...",
+  "tool.inspector.line": "Ligne {0}",
   "roleplay.job.citizen.name": "Citoyen",
   "roleplay.job.citizen.description": "Un membre ordinaire de la société sans rôle spécialisé.",
   "roleplay.job.cook.name": "Cuisinier",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -924,6 +924,7 @@
   "notify.construct.not_found": "Impossible de trouver la construction",
   "notify.construct.limit": "Vous avez atteint votre limite",
   "notify.construct.blocked_by_player": "Apparition bloquée par un joueur dans la zone",
+  "notify.construct.text_empty": "Au moins une ligne doit contenir du texte",
   "notify.stacker.invalid_count": "Nombre d'empilement invalide",
   "notify.stacker.invalid_offset": "Décalage d'empilement invalide",
   "notify.stacker.invalid_target": "Vous devez cibler un prop valide pour empiler",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -924,6 +924,7 @@
   "notify.construct.not_found": "구조물을 찾을 수 없습니다",
   "notify.construct.limit": "한도에 도달했습니다",
   "notify.construct.blocked_by_player": "해당 지역에 플레이어가 있어 스폰이 차단되었습니다",
+  "notify.construct.text_empty": "최소 한 줄에 텍스트가 있어야 합니다",
   "notify.stacker.invalid_count": "잘못된 배치 수량입니다",
   "notify.stacker.invalid_offset": "잘못된 배치 간격입니다",
   "notify.stacker.invalid_target": "유효한 프롭을 대상으로 지정해야 합니다",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -769,6 +769,7 @@
   "tool.inspector.material_selected": "재질 선택 완료",
   "tool.inspector.reset_settings": "설정 초기화",
   "tool.inspector.text_placeholder": "텍스트를 입력하세요...",
+  "tool.inspector.line": "{0}번째 줄",
   "roleplay.job.citizen.name": "시민",
   "roleplay.job.citizen.description": "특별한 역할 없이 사회를 살아가는 일반 시민입니다.",
   "roleplay.job.cook.name": "요리사",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -924,6 +924,7 @@
   "notify.construct.not_found": "Nie można znaleźć konstrukcji",
   "notify.construct.limit": "Osiągnięto limit",
   "notify.construct.blocked_by_player": "Tworzenie zablokowane przez gracza w okolicy",
+  "notify.construct.text_empty": "Co najmniej jedna linia musi zawierać tekst",
   "notify.stacker.invalid_count": "Nieprawidłowa liczba stosów",
   "notify.stacker.invalid_offset": "Nieprawidłowe przesunięcie stosu",
   "notify.stacker.invalid_target": "Musisz celować w prawidłowy obiekt, aby go ułożyć",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -769,6 +769,7 @@
   "tool.inspector.material_selected": "Materiał wybrany",
   "tool.inspector.reset_settings": "Resetuj ustawienia",
   "tool.inspector.text_placeholder": "Wpisz tekst...",
+  "tool.inspector.line": "Linia {0}",
   "roleplay.job.citizen.name": "Obywatel",
   "roleplay.job.citizen.description": "Zwykły członek społeczeństwa bez wyspecjalizowanej roli.",
   "roleplay.job.cook.name": "Kucharz",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -924,6 +924,7 @@
   "notify.construct.not_found": "Постройка не найдена",
   "notify.construct.limit": "Достигнут предел построек",
   "notify.construct.blocked_by_player": "Игрок в зоне спавна блокирует постройку",
+  "notify.construct.text_empty": "Хотя бы одна строка должна содержать текст",
   "notify.stacker.invalid_count": "Неверное количество стаков",
   "notify.stacker.invalid_offset": "Неверное смещение стака",
   "notify.stacker.invalid_target": "Нужно выбрать верный проп для стака",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -769,6 +769,7 @@
   "tool.inspector.material_selected": "Материал выбран",
   "tool.inspector.reset_settings": "Сбросить настройки",
   "tool.inspector.text_placeholder": "Введите текст...",
+  "tool.inspector.line": "Строка {0}",
   "roleplay.job.citizen.name": "Гражданин",
   "roleplay.job.citizen.description": "Обычный член общества без специализации.",
   "roleplay.job.cook.name": "Повар",


### PR DESCRIPTION
Summary
-------

-   Replaces the single-line Text construct with a multiline one supporting up to 4 independent lines
-   Each line has its own text, font size, color, italic, font weight, and outline settings
-   The tool inspector is redesigned around a tab bar --- one tab per line --- to keep the UI uncluttered regardless of line count
-   Existing placed texts (schema v1) are migrated automatically on load, no data loss

Changes
-------

**Data layer** --- `TextData` moves to schema v2, replacing flat fields with `List<TextLineData>`. `TextDefinition.Migrate` converts v1 payloads (flat fields → single-element list). `ConstructDefinition` gained a `virtual Migrate` method so definitions can override it cleanly.

**Rendering** --- `Text.cs` now creates one child `GameObject` per visible line on each `OnDataChanged`, each carrying its own `TextRenderer`. Lines are stacked vertically in local space, centered around the root. Empty lines are skipped silently. When all lines are empty the root `TextRenderer` shows the "Hello! ❤" placeholder.

**Tool** --- `TextTool` exposes `AddLine` / `RemoveLine` / `UpdateLine` / `ResetLines` and a `SelectedLine` index. `TextLineProxy` wraps per-line access with `[Property]` / `[Title]` / `[Range]` attributes so `TypeLibrary.GetSerializedObject` can drive the inspector controls.

**Inspector** --- `TextToolInspector` renders a tab bar for line selection and the same slider/toggle/color/text-entry controls as `DefaultToolInspector` for the active line's proxy.

**Localization** --- `notify.construct.text_empty` added to all 5 locale files (en / fr / pl / ru / ko).

<img width="1915" height="939" alt="image" src="https://github.com/user-attachments/assets/d5023c3d-4734-4eb9-b57b-22b748a9fb3e" />
<img width="419" height="681" alt="image" src="https://github.com/user-attachments/assets/14dcf29f-25c7-4959-a01d-68d40da5fe2c" />
