### PR TITLE
feat(noclip): Allow dynamic speed adjustment with UI overlay

### DIFF
--- a/game/Code/Player/MoveModes/MoveModeNoClip.cs
+++ b/game/Code/Player/MoveModes/MoveModeNoClip.cs
@@ -47,6 +47,14 @@ public class MoveModeNoClip : MoveMode
 
 	private Vector3.SmoothDamped _smoothedVelocity = new( 0.0f, 0.0f, 0.3f );
 
+	private float _speedScale = 1.0f;
+	private const float MinSpeedScale = 0.25f;
+	private const float MaxSpeedScale = 10.0f;
+	private const float SpeedStep = 0.25f;
+
+	public float SpeedScale => _speedScale;
+	public TimeSince TimeSinceSpeedChanged { get; private set; } = 99f;
+
 	/// <summary>
 	///     Indicates if the player is currently noclipping.
 	/// </summary>
@@ -68,6 +76,20 @@ public class MoveModeNoClip : MoveMode
 		if ( CanNoclip() && Input.Pressed( "Noclip" ) )
 		{
 			IsNoclipping = !IsNoclipping;
+		}
+
+		if ( IsNoclipping )
+		{
+			if ( Input.Pressed( "NoclipSpeedUp" ) )
+			{
+				_speedScale = Math.Clamp( _speedScale + SpeedStep, MinSpeedScale, MaxSpeedScale );
+				TimeSinceSpeedChanged = 0;
+			}
+			else if ( Input.Pressed( "NoclipSpeedDown" ) )
+			{
+				_speedScale = Math.Clamp( _speedScale - SpeedStep, MinSpeedScale, MaxSpeedScale );
+				TimeSinceSpeedChanged = 0;
+			}
 		}
 
 		return IsNoclipping ? 100 : 0;
@@ -137,13 +159,13 @@ public class MoveModeNoClip : MoveMode
 			wishVelocity += Vector3.Down * targetSpeed;
 		}
 
-		// Apply speed multiplier
-		wishVelocity *= SpeedMultiplier;
+		// Apply speed multiplier and scroll-adjusted scale
+		wishVelocity *= SpeedMultiplier * _speedScale;
 
 		// Apply speed limit
-		if ( wishVelocity.Length > MaxSpeed )
+		if ( wishVelocity.Length > MaxSpeed * _speedScale )
 		{
-			wishVelocity = wishVelocity.Normal * MaxSpeed;
+			wishVelocity = wishVelocity.Normal * MaxSpeed * _speedScale;
 		}
 
 		return wishVelocity;

--- a/game/Code/UI/HUD/Components/NoclipSpeedOverlay.razor
+++ b/game/Code/UI/HUD/Components/NoclipSpeedOverlay.razor
@@ -1,0 +1,36 @@
+@namespace Dxura.RP.Game.UI
+@inherits Panel
+@attribute [StyleSheet]
+
+@{
+	var noclip = Player.Local?.Controller?.Components.Get<MoveModeNoClip>();
+	if ( noclip == null || !noclip.IsNoclipping || noclip.TimeSinceSpeedChanged > 2f )
+		return;
+}
+
+<root>
+	<div class="speed-container flex items-center gap-3 rounded px-3 py-2">
+		<i class="material-icons speed-icon">speed</i>
+		<div class="flex flex-col">
+			<span class="speed-label">Noclip Speed</span>
+			<span class="speed-value">×@noclip.SpeedScale.ToString( "0.00" )</span>
+		</div>
+		<div class="flex flex-col gap-1">
+			<div class="flex items-center gap-1">
+				<InputHint Action="NoclipSpeedUp" Size="@InputGlyphSize.Small" Animate="@false"/>
+			</div>
+			<div class="flex items-center gap-1">
+				<InputHint Action="NoclipSpeedDown" Size="@InputGlyphSize.Small" Animate="@false"/>
+			</div>
+		</div>
+	</div>
+</root>
+
+@code
+{
+	protected override int BuildHash()
+	{
+		var noclip = Player.Local?.Controller?.Components.Get<MoveModeNoClip>();
+		return HashCode.Combine( noclip?.IsNoclipping, noclip?.SpeedScale, noclip?.TimeSinceSpeedChanged > 2f );
+	}
+}

--- a/game/Code/UI/HUD/Components/NoclipSpeedOverlay.razor.scss
+++ b/game/Code/UI/HUD/Components/NoclipSpeedOverlay.razor.scss
@@ -1,0 +1,32 @@
+@import "../../styles.scss";
+
+NoclipSpeedOverlay {
+  position: absolute;
+  bottom: 4%;
+  right: 1%;
+
+  .speed-container {
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+  }
+
+  .speed-icon {
+    font-size: 20px;
+    color: $color-accent;
+    opacity: 0.9;
+  }
+
+  .speed-label {
+    font-size: 11px;
+    color: rgba(white, 0.5);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .speed-value {
+    font-size: 18px;
+    font-weight: bold;
+    font-family: monospace;
+    color: $color-accent;
+  }
+}

--- a/game/Code/UI/HUD/HUD.razor
+++ b/game/Code/UI/HUD/HUD.razor
@@ -52,6 +52,7 @@
 			<PlayerInfo/>
 			<Deathcam/>
 			<SpectateOverlay/>
+			<NoclipSpeedOverlay/>
 			<DamageIndicator/>
 			<KillFeed/>
 			<Ammo/>

--- a/game/ProjectSettings/Input.config
+++ b/game/ProjectSettings/Input.config
@@ -1,4 +1,4 @@
-{
+  {
   "Actions": [
     {
       "Name": "Forward",
@@ -271,6 +271,20 @@
       "GroupName": "Other",
       "Title": null,
       "KeyboardCode": "mouse3",
+      "GamepadCode": "None"
+    },
+    {
+      "Name": "NoclipSpeedUp",
+      "GroupName": "Player",
+      "Title": "Noclip Speed Up",
+      "KeyboardCode": "UP",
+      "GamepadCode": "None"
+    },
+    {
+      "Name": "NoclipSpeedDown",
+      "GroupName": "Player",
+      "Title": "Noclip Speed Down",
+      "KeyboardCode": "DOWN",
       "GamepadCode": "None"
     }
   ],


### PR DESCRIPTION
This pull request introduces a noclip speed adjustment feature for players in noclip mode, including both gameplay logic and a user interface overlay to display and control the current speed multiplier. The main changes add new input bindings for speed control, update the movement logic to respect the adjustable speed, and provide a UI overlay that informs players of their current noclip speed and input hints.

**Gameplay: Noclip Speed Adjustment**
- Added a speed scaling system to `MoveModeNoClip`, allowing players to increase or decrease their noclip movement speed within a defined range using new input actions (`NoclipSpeedUp` and `NoclipSpeedDown`). The speed multiplier is applied to all noclip movement calculations.

**Input Bindings**
- Defined new input actions for increasing and decreasing noclip speed in `Input.config`, mapped to the UP and DOWN arrow keys.

<img width="833" height="494" alt="image" src="https://github.com/user-attachments/assets/3ee6a701-8fd5-422e-997a-3d2a5c185d5f" />
<img width="170" height="117" alt="image" src="https://github.com/user-attachments/assets/3b3add2e-557c-46ee-9fc5-0a9bcf0e95a1" />

Original idea -> https://discord.com/channels/1007143370877042738/1508384954914963466