### PR TITLE
fix: Disable damage when cloak

### DIFF
--- a/game/Code/Player/Status/Statuses/CloakStatus.cs
+++ b/game/Code/Player/Status/Statuses/CloakStatus.cs
@@ -10,6 +10,7 @@ public class CloakStatus : BaseStatus
 	public override bool RemoveOnDeath => true;
 	public override bool RemoveOnRespawn => true;
 	public override bool RemoveOnJobChange => true;
+	public override float ModifyDamageTaken( Player player ) => 0f;
 
 	public override void OnAddedBroadcast( Player player )
 	{


### PR DESCRIPTION
This pull request introduces a small but important change to the `CloakStatus` class. The update ensures that players with this status now take zero damage.

* [`CloakStatus`](diffhunk://#diff-6fde41c4e0d757d21ece544eadc7cb1e6d09f3b3f8c56ff41cebfeac3bac5290R13): Added an override for `ModifyDamageTaken` to always return `0f`, making affected players immune to damage.