### PR TITLE
fix(clipping): prevent clipping by scaled props

### DIFF
--- a/game/Code/Construct/Constructs/Prop/Prop.Modify.cs
+++ b/game/Code/Construct/Constructs/Prop/Prop.Modify.cs
@@ -159,9 +159,15 @@ public partial class Prop
 		ModelCollider.Elasticity = elasticity;
 	}
 
-	private void SetScale( Vector3 scale )
+	private void SetScale( Vector3 scale, bool change )
 	{
 		GameObject.WorldScale = scale;
+
+		if ( Networking.IsHost && change )
+		{
+			var collideGuard = GetOrAddComponent<CollideGuard>();
+			collideGuard.ResetTimer();
+		}
 	}
 
 	private void SetNoCollide( bool noCollide, bool change )

--- a/game/Code/Construct/Constructs/Prop/Prop.cs
+++ b/game/Code/Construct/Constructs/Prop/Prop.cs
@@ -48,10 +48,7 @@ public partial class Prop() : BaseConstruct( ConstructType.Prop ), IDamageEvents
 			SetTint( newPropData.Tint );
 		}
 
-		if ( oldPropData.Scale != newPropData.Scale )
-		{
-			SetScale( newPropData.Scale );
-		}
+		SetScale( newPropData.Scale, oldPropData.Scale != newPropData.Scale );
 
 		SetNoCollide( newPropData.NoCollide, oldPropData.NoCollide != newPropData.NoCollide );
 


### PR DESCRIPTION
Apply temporary playerclip protection after scaling props so the scale tool.