### PR TITLE
fix(#57): block mayor self-recruit after death during recruitment drive

### DIFF
--- a/game/Code/Chat/Commands/JobCommand.cs
+++ b/game/Code/Chat/Commands/JobCommand.cs
@@ -69,41 +69,43 @@ public class JobCommand : ICommand
 			return;
 		}
 
-		var ignoreJobRequirements = GameManager.Instance.IsValid() && GameManager.Instance.IgnoreJobRequirements;
-		if ( job.VoteRequired && !ignoreJobRequirements )
+		if ( job.VoteRequired )
 		{
-			var jobCooldownId = $"{caller.SteamId}:job:vote:{job.Id}";
-			if ( Cooldown.Current.IsOnCooldown( jobCooldownId ) )
+			if ( TryWarnJobCooldown( caller, job, $"{caller.SteamId}:job:{job.Id}" ) )
 			{
-				var remainingTime = Cooldown.Current.GetRemainingTime( jobCooldownId );
-				caller.Warn( string.Format(
-					Language.GetPhrase( "notify.vote.cooldown" ),
-					job.DisplayName(),
-					remainingTime ) );
 				return;
 			}
 
-			var voteCooldownId = $"{caller.SteamId}:vote";
-			if ( Cooldown.Current.IsOnCooldown( voteCooldownId ) )
+			var ignoreJobRequirements = GameManager.Instance.IsValid() && GameManager.Instance.IgnoreJobRequirements;
+			if ( !ignoreJobRequirements )
 			{
-				caller.Cooldown( voteCooldownId );
+				if ( TryWarnJobCooldown( caller, job, $"{caller.SteamId}:job:vote:{job.Id}" ) )
+				{
+					return;
+				}
+
+				var voteCooldownId = $"{caller.SteamId}:vote";
+				if ( Cooldown.Current.IsOnCooldown( voteCooldownId ) )
+				{
+					caller.Cooldown( voteCooldownId );
+					return;
+				}
+
+				if ( !VoteSystem.Instance.IsValid() )
+				{
+					caller.Error( "#generic.error" );
+					return;
+				}
+
+				if ( VoteSystem.Instance.StartVoteForPlayerHost( caller, caller.SteamId, VoteType.Job, customData: job.Id.ToString() ) )
+				{
+					caller.Success( string.Format(
+						Language.GetPhrase( "command.job.vote_started" ),
+						job.DisplayName() ) );
+				}
+
 				return;
 			}
-
-			if ( !VoteSystem.Instance.IsValid() )
-			{
-				caller.Error( "#generic.error" );
-				return;
-			}
-
-			if ( VoteSystem.Instance.StartVoteForPlayerHost( caller, caller.SteamId, VoteType.Job, customData: job.Id.ToString() ) )
-			{
-				caller.Success( string.Format(
-					Language.GetPhrase( "command.job.vote_started" ),
-					job.DisplayName() ) );
-			}
-
-			return;
 		}
 
 		var cooldownId = $"{caller.SteamId}:job:change";
@@ -199,6 +201,20 @@ public class JobCommand : ICommand
 		return candidates.FirstOrDefault( job =>
 			NormalizeJobName( job.DisplayName() ).Contains( normalizedInput ) ||
 			NormalizeJobName( job.Name ).Contains( normalizedInput ) );
+	}
+
+	private static bool TryWarnJobCooldown( Player caller, GameModeJobDto job, string cooldownId )
+	{
+		if ( !Cooldown.Current.IsOnCooldown( cooldownId ) )
+		{
+			return false;
+		}
+
+		caller.Warn( string.Format(
+			Language.GetPhrase( "notify.vote.cooldown" ),
+			job.DisplayName(),
+			Cooldown.Current.GetRemainingTime( cooldownId ) ) );
+		return true;
 	}
 
 	private static string NormalizeJobName( string value )

--- a/game/Code/System/RespawnerSystem.cs
+++ b/game/Code/System/RespawnerSystem.cs
@@ -166,7 +166,13 @@ public class RespawnerSystem : SingletonComponent<RespawnerSystem>, IGameEvents
 
 		Log.Info( $"Demoting player {player.DisplayName} due to death" );
 
+		var demotedFromJob = player.Job.Id;
+
 		// Demote to citizen
 		player.Job = GameModeJobs.GetByTagOrFallback( JobTag.Citizen, "Citizen" );
+
+		Cooldown.Current.StartCooldown(
+			$"{player.SteamId}:job:{demotedFromJob}",
+			Config.Current.Game.DemoteJobReapplyCooldown );
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #57  a mayor could activate Recruitment Drive, die, and immediately reclaim the mayor job without waiting for the normal reapply cooldown.

Recruitment Drive bypasses vote requirements via `IgnoreJobRequirements`, so after death demotion the ex-mayor could rejoin instantly instead of waiting like after a demote vote.

## Changes
- Apply `DemoteJobReapplyCooldown` when a player is demoted on death (`DemoteOnRespawn`)
- Enforce the reapply cooldown in `/job` for vote-required jobs, even when Recruitment Drive is active
- Refactor duplicate cooldown warning logic in `JobCommand` into `TryWarnJobCooldown`
