### PR TITLE
feat(#46): add inactivity timer

### DIFF
--- a/game/Code/Player/Player.Afk.cs
+++ b/game/Code/Player/Player.Afk.cs
@@ -1,0 +1,14 @@
+namespace Dxura.RP.Game;
+
+public partial class Player
+{
+	/// <summary>
+	///     When the player became AFK. Synced from host; null when not AFK.
+	/// </summary>
+	[Sync( SyncFlags.FromHost )]
+	public TimeSince? AfkSince { get; set; }
+
+	public float AfkDuration => AfkSince?.Relative ?? 0f;
+
+	public string GetAfkDurationText() => TimeUtils.Format( AfkDuration, TimeDisplayFormat.Duration );
+}

--- a/game/Code/Player/Status/Statuses/AfkStatus.cs
+++ b/game/Code/Player/Status/Statuses/AfkStatus.cs
@@ -6,4 +6,14 @@ public class AfkStatus : BaseStatus
 	public override string Name => "AFK";
 	public override string? MaterialIcon => "pause";
 	public override Color Color => Color.FromRgb( 0xFFC107 );
+
+	public override void OnAddedServer( Player player )
+	{
+		player.AfkSince = 0f;
+	}
+
+	public override void OnRemovedServer( Player player )
+	{
+		player.AfkSince = null;
+	}
 }

--- a/game/Code/UI/Gameplay/Minigame/MinigameAutoCountdown.razor
+++ b/game/Code/UI/Gameplay/Minigame/MinigameAutoCountdown.razor
@@ -10,7 +10,7 @@
 			@* Show next minigame countdown when no active minigame *@
 			var nextTime = Math.Max(0, MinigameSystem.Instance?.NextAutoMinigameTime ?? 0);
 			<p class="text-2xl uppercase text-gray-400">#minigame.next</p>
-			<h2 class="text-2xl text-accent text-bold">@FormatTime(nextTime)</h2>
+			<h2 class="text-2xl text-accent text-bold">@TimeUtils.FormatDuration(nextTime)</h2>
 		}
 		else
 		{
@@ -20,7 +20,7 @@
 				case MinigameState.Seeding:
 					var seedingRemaining = Math.Max(0, 30f - _stateTimer);
 					<p class="text-2xl  text-gray-400 uppercase">#minigame.accepting</p>
-					<h2 class="text-2xl text-accent text-bold">@FormatTime(seedingRemaining)</h2>
+					<h2 class="text-2xl text-accent text-bold">@TimeUtils.FormatDuration(seedingRemaining)</h2>
 					break;
 					
 				case MinigameState.Creating:
@@ -30,13 +30,13 @@
 				case MinigameState.PreLobby:
 					var lobbyRemaining = Math.Max(0, MinigameResource.LobbyDuration - _stateTimer);
 					<p class="text-2xl  text-gray-400 uppercase">#minigame.starting_in</p>
-					<h2 class="text-2xl text-accent text-bold">@FormatTime(lobbyRemaining)</h2>
+					<h2 class="text-2xl text-accent text-bold">@TimeUtils.FormatDuration(lobbyRemaining)</h2>
 					break;
 
 				case MinigameState.Playing:
 					var playingRemaining = Math.Max(0, MinigameResource.Duration - _stateTimer);
 					<p class="text-2xl  text-gray-400 uppercase">#minigame.time_remaining</p>
-					<h2 class="text-2xl text-accent text-bold">@FormatTime(playingRemaining)</h2>
+					<h2 class="text-2xl text-accent text-bold">@TimeUtils.FormatDuration(playingRemaining)</h2>
 					break;
 
 				case MinigameState.PostLobby:
@@ -70,18 +70,6 @@
 			_stateTimer = 0f;
 			_lastState = CurrentState;
 		}
-	}
-
-	string FormatTime(float seconds)
-	{
-		var totalSeconds = (int)Math.Ceiling(seconds);
-		var minutes = totalSeconds / 60;
-		var secs = totalSeconds % 60;
-
-		if (minutes > 0)
-			return $"{minutes}m {secs}s";
-
-		return $"{secs}s";
 	}
 
 	protected override int BuildHash() => HashCode.Combine( Time.Now );

--- a/game/Code/UI/HUD/Components/Gameplay/Jobs/HitmanPanel.razor
+++ b/game/Code/UI/HUD/Components/Gameplay/Jobs/HitmanPanel.razor
@@ -22,7 +22,7 @@
 						<div class="active-hit-info flex flex-col items-center gap-1">
 							<span class="text-lg text-white">@target.DisplayName</span>
 							<span class="text-base text-good">$@HitSystem.ActiveHit.Value.Price.ToString("N0")</span>
-							<span class="text-sm text-tertiary">@string.Format( Language.GetPhrase( "hit.panel.time" ), FormatTimeRemaining(HitSystem.ActiveHit.Value.TimeSinceRequested) )</span>
+							<span class="text-sm text-tertiary">@string.Format( Language.GetPhrase( "hit.panel.time" ), GetHitTimeRemaining() )</span>
 						</div>
 					}
 					else
@@ -136,16 +136,17 @@
 		return HashCode.Combine( Player.Job, _isHidden, Price, CurrentTargetName, HitSystem.PendingHitRequests.Count, HasHit, Time.Now );
 	}
 
-	private string FormatTimeRemaining( TimeSince timeSince )
+	private string GetHitTimeRemaining()
 	{
+		var timeSince = HitSystem.ActiveHit!.Value.TimeSinceRequested;
 		var totalSeconds = Config.Current.Game.HitmanActiveHitDuration - timeSince;
+
 		if ( totalSeconds <= 0 )
+		{
 			return Language.GetPhrase( "hit.panel.expired" );
+		}
 
-		var minutes = (int)(totalSeconds / 60);
-		var seconds = (int)(totalSeconds % 60);
-
-		return $"{minutes}:{seconds:D2}";
+		return TimeUtils.FormatCountdown( totalSeconds, padMinutes: false );
 	}
 
 	private void ToggleHide()

--- a/game/Code/UI/HUD/Components/Gameplay/World/CinemaUi.razor
+++ b/game/Code/UI/HUD/Components/Gameplay/World/CinemaUi.razor
@@ -50,7 +50,7 @@
 				<span class="text-sm text-bold text-white">@( cinema.NowPlayingTitle ?? Language.GetPhrase( "cinema.ui.nothing" ) )</span>
 				@if ( cinema.NowPlayingDurationSeconds > 0 )
 				{
-					<span class="text-xs text-accent">@FormatTime( cinema.NowPlayingElapsedSeconds ) / @FormatTime( cinema.NowPlayingDurationSeconds )</span>
+					<span class="text-xs text-accent">@TimeUtils.FormatClock( cinema.NowPlayingElapsedSeconds ) / @TimeUtils.FormatClock( cinema.NowPlayingDurationSeconds )</span>
 				}
 			</div>
 
@@ -182,14 +182,6 @@
 		var cinema = Cinema.Local;
 		if ( cinema == null || !cinema.IsValid() ) return;
 		cinema.VoteSkipHost();
-	}
-
-	private static string FormatTime( float totalSeconds )
-	{
-		var ts = TimeSpan.FromSeconds( Math.Max( 0, totalSeconds ) );
-		return ts.TotalHours >= 1
-			? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
-			: $"{ts.Minutes}:{ts.Seconds:D2}";
 	}
 
 	public override void Tick()

--- a/game/Code/UI/HUD/Voting.razor
+++ b/game/Code/UI/HUD/Voting.razor
@@ -70,7 +70,7 @@
 
 					<div class="vote-timer-bar">
 						<div class="vote-timer-fill" style="width: @( timeProgress * 100 )%"></div>
-						<label class="vote-timer-text">@FormatTimeRemaining( remainingTime )</label>
+						<label class="vote-timer-text">@TimeUtils.FormatCountdown( remainingTime )</label>
 					</div>
 
 					<div class="vote-actions flex">
@@ -120,14 +120,6 @@
 		}
 
 		_dismissedVotes.RemoveWhere( voteId => !VoteSystem.Instance.ActiveVotes.ContainsKey( voteId ) );
-	}
-
-	private string FormatTimeRemaining( float seconds )
-	{
-		var minutes = (int)(seconds / 60);
-		var remainingSeconds = (int)(seconds % 60);
-
-		return $"{minutes:D2}:{remainingSeconds:D2}";
 	}
 
 	protected override int BuildHash()

--- a/game/Code/UI/Menus/BuildMenu/Components/AssetList/AssetCard.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/AssetList/AssetCard.razor
@@ -67,7 +67,7 @@
 
 					@if ( Package.Interaction.Used )
 					{
-						<div tooltip="#assetlist.hours_tooltip"><i>alarm</i> @FormatHoursPlayed()</div>
+						<div tooltip="#assetlist.hours_tooltip"><i>alarm</i> @TimeUtils.FormatHoursCompact( Package.Interaction.Seconds )</div>
 					}
 
 				</div>
@@ -112,21 +112,6 @@
 
 			return "";
 		}
-	}
-
-	public string FormatHoursPlayed()
-	{
-		var minutes = Package.Interaction.Seconds / 60.0;
-
-		if ( minutes < 60 )
-			return minutes.ToString( "0m" );
-
-		var hours = Package.Interaction.Seconds / 60.0 / 60.0;
-
-		if ( hours > 10 )
-			return hours.ToString( "0h" );
-
-		return hours.ToString( "0.#h" );
 	}
 
 	public string UpdatedString()

--- a/game/Code/UI/Menus/TabMenu/Sections/Components/PlayerSanctionHistory.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/Components/PlayerSanctionHistory.razor
@@ -32,7 +32,7 @@
 							<span class="duration">@durationText</span>
 						}
 					</div>
-					<span class="issued-at" tooltip="@FormatAbsoluteTimestamp( sanction.Created )">@FormatCreatedTimestamp( sanction.Created )</span>
+					<span class="issued-at" tooltip="@TimeUtils.FormatAbsolute( sanction.Created )">@TimeUtils.FormatRelative( sanction.Created )</span>
 				</div>
 
 				<div class="reason" tooltip="@( HasNotes( sanction.Notes ) ? sanction.Notes : null )">@sanction.Reason</div>
@@ -135,40 +135,6 @@
 		SanctionType.Note => "note",
 		_ => "default"
 	};
-
-	private static string FormatCreatedTimestamp( DateTimeOffset timestamp )
-	{
-		var elapsed = DateTimeOffset.Now - timestamp.ToLocalTime();
-		if ( elapsed <= TimeSpan.Zero )
-		{
-			return "just now";
-		}
-
-		if ( elapsed < TimeSpan.FromMinutes( 1 ) )
-		{
-			return "<1 min ago";
-		}
-
-		if ( elapsed < TimeSpan.FromHours( 1 ) )
-		{
-			var minutes = (int)Math.Floor( elapsed.TotalMinutes );
-			return $"{minutes} min{(minutes == 1 ? string.Empty : "s")} ago";
-		}
-
-		if ( elapsed < TimeSpan.FromDays( 1 ) )
-		{
-			var hours = (int)Math.Floor( elapsed.TotalHours );
-			var minutes = elapsed.Minutes;
-			return minutes == 0
-				? $"{hours}h ago"
-				: $"{hours}h {minutes}m ago";
-		}
-
-		var days = (int)Math.Floor( elapsed.TotalDays );
-		return $"{days} day{(days == 1 ? string.Empty : "s")} ago";
-	}
-
-	private static string FormatAbsoluteTimestamp( DateTimeOffset timestamp ) => timestamp.LocalDateTime.ToString( "g" );
 
 	private static bool HasNotes( string? notes ) => !string.IsNullOrWhiteSpace( notes );
 

--- a/game/Code/UI/Menus/TabMenu/Sections/DashboardTabMenuSection.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/DashboardTabMenuSection.razor
@@ -35,7 +35,7 @@
 					<i class="material-icons">schedule</i>
 				</div>
 				<div class="stat-text">
-					<span class="stat-value">@( FormatUptime( Time.Now ) )</span>
+					<span class="stat-value">@( TimeUtils.FormatUptime( Time.Now ) )</span>
 					<span class="stat-label">#tabmenu.dashboard.uptime</span>
 				</div>
 			</div>
@@ -59,7 +59,7 @@
 					<i class="material-icons">timer</i>
 				</div>
 				<div class="stat-text">
-					<span class="stat-value">@( FormatUptime( GameManager.Instance.SessionTime ) )</span>
+					<span class="stat-value">@( TimeUtils.FormatUptime( GameManager.Instance.SessionTime ) )</span>
 					<span class="stat-label">#tabmenu.dashboard.session</span>
 				</div>
 			</div>
@@ -272,13 +272,5 @@
 	protected override int BuildHash()
 	{
 		return HashCode.Combine( IsPlayerDead(), Governance.Current.GetAllLaws().Count(), Governance.Current.GovernmentBalance, Governance.Current.TaxRate, ((float)GameManager.Instance.SessionTime).FloorToInt() );
-	}
-	
-	private static string FormatUptime(float seconds)
-	{
-		var ts = TimeSpan.FromSeconds(seconds);
-		return ts.TotalHours >= 24 
-			? $"{(int)ts.TotalDays}d {ts.Hours}h {ts.Minutes}m"
-			: $"{(int)ts.TotalHours}h {ts.Minutes}m";
 	}
 }

--- a/game/Code/UI/Menus/TabMenu/Sections/GovernanceTabMenuSection.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/GovernanceTabMenuSection.razor
@@ -71,7 +71,7 @@
 								{
 									@if ( remaining > 0 )
 									{
-										<span class="text-xs" style="color: #44ff44;">@(TimeSpan.FromSeconds( remaining ).ToString( @"mm\:ss" ))</span>
+										<span class="text-xs" style="color: #44ff44;">@TimeUtils.FormatCountdown( remaining )</span>
 									}
 									else
 									{
@@ -186,7 +186,7 @@
 												var timeLeft = warrantPlayer.GetStatusExpiry(Constants.WarrantStatus);
 												if (timeLeft.HasValue)
 												{
-													<span>@Language.GetPhrase( "governance.warrants.time_left" ) @(TimeSpan.FromSeconds(timeLeft.Value.Relative).ToString(@"mm\:ss"))</span>
+													<span>@Language.GetPhrase( "governance.warrants.time_left" ) @TimeUtils.FormatCountdown( timeLeft.Value.Relative )</span>
 												}
 											}
 										</span>

--- a/game/Code/UI/Menus/TabMenu/Sections/PlayersTabMenuSection.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/PlayersTabMenuSection.razor
@@ -166,7 +166,7 @@
 							}
 							else if ( player.HasStatus( Constants.AfkStatus ) )
 							{
-								<i class="material-icons text-warning text-sm" tooltip="#tabmenu.players.status.afk">schedule</i>
+								<i class="material-icons text-warning text-sm" tooltip="@string.Format( Language.GetPhrase( "tabmenu.players.status.afk_duration" ), player.GetAfkDurationText() )">schedule</i>
 							}
 							
 							@if ( IsPartyMember( player ) )

--- a/game/Code/Utilities/TimeUtils.cs
+++ b/game/Code/Utilities/TimeUtils.cs
@@ -1,0 +1,145 @@
+namespace Dxura.RP.Game;
+
+public enum TimeDisplayFormat
+{
+	/// <summary>Compact elapsed time: 5m 30s, 30s</summary>
+	Duration,
+
+	/// <summary>Long-running uptime: 2h 15m, 1d 3h 20m</summary>
+	Uptime,
+
+	/// <summary>Media clock: 5:30, 1:05:30</summary>
+	Clock,
+
+	/// <summary>Padded countdown: 05:30</summary>
+	Countdown,
+
+	/// <summary>Compact countdown: 5:30</summary>
+	CountdownShort,
+
+	/// <summary>Compact hours played: 45m, 2.5h, 12h</summary>
+	HoursCompact,
+}
+
+public static class TimeUtils
+{
+	public static string Format( float seconds, TimeDisplayFormat format = TimeDisplayFormat.Duration ) =>
+		format switch
+		{
+			TimeDisplayFormat.Duration => FormatDuration( seconds ),
+			TimeDisplayFormat.Uptime => FormatUptime( seconds ),
+			TimeDisplayFormat.Clock => FormatClock( seconds ),
+			TimeDisplayFormat.Countdown => FormatCountdown( seconds ),
+			TimeDisplayFormat.CountdownShort => FormatCountdown( seconds, padMinutes: false ),
+			TimeDisplayFormat.HoursCompact => FormatHoursCompact( seconds ),
+			_ => FormatDuration( seconds ),
+		};
+
+	public static string Format( TimeSince timeSince, TimeDisplayFormat format = TimeDisplayFormat.Duration ) =>
+		Format( timeSince.Relative, format );
+
+	public static string Format( TimeSpan timeSpan, TimeDisplayFormat format = TimeDisplayFormat.Duration ) =>
+		Format( (float)timeSpan.TotalSeconds, format );
+
+	/// <summary>Compact elapsed time: 5m 30s, 30s</summary>
+	public static string FormatDuration( float seconds )
+	{
+		var totalSeconds = (int)Math.Ceiling( Math.Max( 0, seconds ) );
+		var minutes = totalSeconds / 60;
+		var secs = totalSeconds % 60;
+
+		if ( minutes > 0 )
+		{
+			return $"{minutes}m {secs}s";
+		}
+
+		return $"{secs}s";
+	}
+
+	/// <summary>Long-running uptime: 2h 15m, 1d 3h 20m</summary>
+	public static string FormatUptime( float seconds )
+	{
+		var ts = TimeSpan.FromSeconds( Math.Max( 0, seconds ) );
+
+		return ts.TotalHours >= 24
+			? $"{(int)ts.TotalDays}d {ts.Hours}h {ts.Minutes}m"
+			: $"{(int)ts.TotalHours}h {ts.Minutes}m";
+	}
+
+	/// <summary>Media clock: 5:30, 1:05:30</summary>
+	public static string FormatClock( float seconds )
+	{
+		var ts = TimeSpan.FromSeconds( Math.Max( 0, seconds ) );
+
+		return ts.TotalHours >= 1
+			? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
+			: $"{ts.Minutes}:{ts.Seconds:D2}";
+	}
+
+	/// <summary>Countdown timer: 05:30 or 5:30</summary>
+	public static string FormatCountdown( float seconds, bool padMinutes = true )
+	{
+		var totalSeconds = Math.Max( 0, (int)seconds );
+		var minutes = totalSeconds / 60;
+		var secs = totalSeconds % 60;
+
+		return padMinutes
+			? $"{minutes:D2}:{secs:D2}"
+			: $"{minutes}:{secs:D2}";
+	}
+
+	/// <summary>Compact hours played: 45m, 2.5h, 12h</summary>
+	public static string FormatHoursCompact( float seconds )
+	{
+		var minutes = seconds / 60.0;
+
+		if ( minutes < 60 )
+		{
+			return minutes.ToString( "0m" );
+		}
+
+		var hours = seconds / 3600.0;
+
+		return hours > 10
+			? hours.ToString( "0h" )
+			: hours.ToString( "0.#h" );
+	}
+
+	/// <summary>Relative timestamp: just now, 5 mins ago, 2h ago</summary>
+	public static string FormatRelative( DateTimeOffset timestamp )
+	{
+		var elapsed = DateTimeOffset.Now - timestamp.ToLocalTime();
+
+		if ( elapsed <= TimeSpan.Zero )
+		{
+			return "just now";
+		}
+
+		if ( elapsed < TimeSpan.FromMinutes( 1 ) )
+		{
+			return "<1 min ago";
+		}
+
+		if ( elapsed < TimeSpan.FromHours( 1 ) )
+		{
+			var minutes = (int)Math.Floor( elapsed.TotalMinutes );
+			return $"{minutes} min{(minutes == 1 ? string.Empty : "s")} ago";
+		}
+
+		if ( elapsed < TimeSpan.FromDays( 1 ) )
+		{
+			var hours = (int)Math.Floor( elapsed.TotalHours );
+			var minutes = elapsed.Minutes;
+
+			return minutes == 0
+				? $"{hours}h ago"
+				: $"{hours}h {minutes}m ago";
+		}
+
+		var days = (int)Math.Floor( elapsed.TotalDays );
+		return $"{days} day{(days == 1 ? string.Empty : "s")} ago";
+	}
+
+	public static string FormatAbsolute( DateTimeOffset timestamp ) =>
+		timestamp.LocalDateTime.ToString( "g" );
+}

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -52,6 +52,7 @@
   "tabmenu.players.permission.door": "Toggle door permission for this player",
   "tabmenu.players.status.disconnected": "Disconnected",
   "tabmenu.players.status.afk": "AFK",
+  "tabmenu.players.status.afk_duration": "AFK since {0}",
   "tabmenu.players.steamid": "SteamID: {0}",
   "tabmenu.players.teleport_to": "Goto",
   "tabmenu.players.bring": "Bring",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -52,6 +52,7 @@
   "tabmenu.players.permission.door": "Basculer permission des portes",
   "tabmenu.players.status.disconnected": "Déconnecté",
   "tabmenu.players.status.afk": "AFK",
+  "tabmenu.players.status.afk_duration": "AFK depuis {0}",
   "tabmenu.players.steamid": "SteamID : {0}",
   "tabmenu.players.teleport_to": "Se téléporter à",
   "tabmenu.players.bring": "Amener",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -52,6 +52,7 @@
   "tabmenu.players.permission.door": "이 플레이어에게 도어 권한 허용/거부",
   "tabmenu.players.status.disconnected": "접속해제됨",
   "tabmenu.players.status.afk": "자리비움",
+  "tabmenu.players.status.afk_duration": "{0} 동안 자리비움",
   "tabmenu.players.steamid": "스팀고유번호: {0}",
   "tabmenu.players.teleport_to": "강림",
   "tabmenu.players.bring": "소환",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -52,6 +52,7 @@
   "tabmenu.players.permission.door": "Przełącz uprawnienia do drzwi dla tego gracza",
   "tabmenu.players.status.disconnected": "Rozłączony",
   "tabmenu.players.status.afk": "Nieobecny",
+  "tabmenu.players.status.afk_duration": "Nieobecny od {0}",
   "tabmenu.players.steamid": "SteamID: {0}",
   "tabmenu.players.teleport_to": "Idź do",
   "tabmenu.players.bring": "Przywołaj",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -52,6 +52,7 @@
   "tabmenu.players.permission.door": "Разрешить/запретить доступ к дверям",
   "tabmenu.players.status.disconnected": "Отключен",
   "tabmenu.players.status.afk": "AFK",
+  "tabmenu.players.status.afk_duration": "AFK {0}",
   "tabmenu.players.steamid": "SteamID: {0}",
   "tabmenu.players.teleport_to": "Телепорт к",
   "tabmenu.players.bring": "Телепорт к себе",


### PR DESCRIPTION
## Summary
- `feat(afk)`: sync `AfkSince` from host when AFK status is applied or removed
- `feat(ui)`: show elapsed AFK time on tab menu tooltip
- `refactor(ui)`: introduce `TimeUtils` and migrate existing duration formatters

<img width="1254" height="123" alt="image" src="https://github.com/user-attachments/assets/e47970ed-0a4c-4289-946f-d797aa51a0ab" />


Closes #46
