### PR TITLE
fix(#63): implement proper SR latch set/reset logic

### DIFF
--- a/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
+++ b/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
@@ -181,7 +181,7 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 			GateType.Select => numA > GateWireDefinition.GateBooleanThreshold ? InputB : InputC,
 			GateType.Threshold => numA > numB ? GateWireDefinition.GateLogicHigh : GateWireDefinition.GateLogicLow,
 			GateType.Invert => -numA,
-			GateType.Latch => UpdateSrLatch( boolInputA ),
+			GateType.Latch => UpdateSrLatch( boolInputA, boolInputB ),
 
 			// String operations
 			GateType.Concat => strA + strB + strC + strD + strE,
@@ -272,13 +272,18 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 		return input.Substring( start, len );
 	}
 
-	private bool UpdateSrLatch( bool inputA )
+	private float UpdateSrLatch( bool set, bool reset )
 	{
-		if ( inputA )
+		if ( _inputBLinked && reset )
 		{
-			_srLatchOutput = !_srLatchOutput;
+			_srLatchOutput = false;
 		}
-		return _srLatchOutput;
+		else if ( _inputALinked && set )
+		{
+			_srLatchOutput = true;
+		}
+
+		return _srLatchOutput ? GateWireDefinition.GateLogicHigh : GateWireDefinition.GateLogicLow;
 	}
 
 	/// <summary>

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -639,7 +639,7 @@
   "gatetype.vector2": "Vector2 ( (A, B) → Out )",
   "gatetype.vector3": "Vector3 ( (A, B, C) → Out )",
   "gatetype.vectorget": "VectorGet ( A(x, y, z), B → Out = A[B] )",
-  "gatetype.srlatch": "SRLatch (A↑ ? !Output : Output → Out)",
+  "gatetype.latch": "SR Latch (A=Set, B=Reset → Out holds until reset)",
   "tool.precision.name": "Precision",
   "tool.precision.description": "Precisely position and rotate constructs",
   "tool.precision.too_far": "Too far away",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -639,7 +639,7 @@
   "gatetype.vector2": "Vecteur2 ( (A, B) → Out )",
   "gatetype.vector3": "Vecteur3 ( (A, B, C) → Out )",
   "gatetype.vectorget": "VectorGet ( A[B] → Out )",
-  "gatetype.srlatch": "Bascule SR (SRLatch)",
+  "gatetype.latch": "Bascule SR (A=Set, B=Reset → sortie maintenue jusqu'au reset)",
   "tool.precision.name": "Précision",
   "tool.precision.description": "Positionner et faire pivoter précisément des constructions",
   "tool.precision.too_far": "Trop loin",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -639,7 +639,7 @@
   "gatetype.vector2": "벡터2 (A, B → 출력)",
   "gatetype.vector3": "벡터3 (A, B, C → 출력)",
   "gatetype.vectorget": "벡터 추출 (A[x,y,z], B → 출력 = A[B])",
-  "gatetype.srlatch": "SR 래치 (A↑ ? !출력 : 출력 → 출력)",
+  "gatetype.latch": "SR 래치 (A=Set, B=Reset → 리셋 전까지 출력 유지)",
   "tool.precision.name": "정밀배치",
   "tool.precision.description": "구조물을 정밀하게 이동 및 회전시킵니다",
   "tool.precision.too_far": "너무 멀리 있습니다.",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -639,7 +639,7 @@
   "gatetype.vector2": "Wektor2 ( (A, B) → Wyj )",
   "gatetype.vector3": "Wektor3 ( (A, B, C) → Wyj )",
   "gatetype.vectorget": "WektorGet ( A(x, y, z), B → Wyj = A[B] )",
-  "gatetype.srlatch": "SRLatch (A↑ ? !Wyjście : Wyjście → Wyj)",
+  "gatetype.latch": "Przerzutnik SR (A=Set, B=Reset → wyjście trzyma stan do resetu)",
   "tool.precision.name": "Precyzja",
   "tool.precision.description": "Precyzyjnie pozycjonuj i obracaj konstrukcje",
   "tool.precision.too_far": "Za daleko",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -639,7 +639,7 @@
   "gatetype.vector2": "Вектор2 (A, B)",
   "gatetype.vector3": "Вектор3 (A, B, C)",
   "gatetype.vectorget": "Получить из вектора (A[B])",
-  "gatetype.srlatch": "SR-Триггер (Latch)",
+  "gatetype.latch": "SR-триггер (A=Set, B=Reset → выход держится до сброса)",
   "tool.precision.name": "Точность (Precision)",
   "tool.precision.description": "Точное позиционирование и вращение построек",
   "tool.precision.too_far": "Слишком далеко",


### PR DESCRIPTION
## Summary
Fixes #44 the Latch gate was incorrectly implemented as a single-input toggle instead of a proper Set/Reset (SR) latch.
- **Input A (Set):** drives output high when active
- **Input B (Reset):** drives output low when active
- **Output:** holds its state when neither input is active
- **Conflict:** Reset takes priority when both Set and Reset are active

Also fixes the localization key from `gatetype.srlatch` to `gatetype.latch` (matching `GateType.Latch`) and updates tooltips in all locales.