### PR TITLE
fix(tv): keep playback active within range without line-of-sight (#58)

### DIFF
--- a/game/Code/Entity/Entities/TvEntity.cs
+++ b/game/Code/Entity/Entities/TvEntity.cs
@@ -85,35 +85,16 @@ public class TvEntity : BaseEntity, IDescription, Component.IPressable
 	{
 		_lastCheck = 0;
 		var playerPosition = Player.Local.Controller.EyePosition;
-		var playerDistance = playerPosition.Distance( WorldPosition );
+		var inRange = playerPosition.Distance( WorldPosition ) <= TvRange;
 
-		// Only do raycast check if we're within basic distance range
-		if ( playerDistance <= TvRange )
+		switch ( _isCurrentlyPlaying )
 		{
-			// Perform raycast from player to TV to check for obstacles
-			var originPos = WorldPosition + WorldRotation * (Vector3.Up * 30 * WorldScale.z) + WorldRotation * Vector3.Forward * 5;
-			var direction = (originPos - playerPosition).Normal;
-
-			var trace = Scene.Trace.Ray( new Ray( playerPosition, direction ), TvRange )
-				.WithTag( "solid" )
-				.WithoutTags( Constants.PlayerTag )
-				.Run();
-
-			var isVisible = trace.GameObject == GameObject;
-
-			switch ( _isCurrentlyPlaying )
-			{
-				case false when playerDistance <= TvRange && isVisible && HasVideoContent():
-					StartPlayback();
-					break;
-				case true when playerDistance > TvRange || !isVisible:
-					StopPlayback();
-					break;
-			}
-		}
-		else if ( _isCurrentlyPlaying )
-		{
-			StopPlayback();
+			case false when inRange && HasVideoContent():
+				StartPlayback();
+				break;
+			case true when !inRange:
+				StopPlayback();
+				break;
 		}
 	}
 

--- a/game/Code/Entity/Entities/TvEntity.cs
+++ b/game/Code/Entity/Entities/TvEntity.cs
@@ -29,6 +29,9 @@ public class TvEntity : BaseEntity, IDescription, Component.IPressable
 	[ConVar( "dx_tv_range", ConVarFlags.Saved, Min = 0, Max = 5000 )]
 	private static int TvRange { get; set; } = 600;
 
+	[ConVar( "dx_tv_line_of_sight", ConVarFlags.Saved )]
+	private static bool RequireLineOfSight { get; set; }
+
 	// True if the TV is currently active and playing content
 	private bool _isCurrentlyPlaying;
 
@@ -85,14 +88,48 @@ public class TvEntity : BaseEntity, IDescription, Component.IPressable
 	{
 		_lastCheck = 0;
 		var playerPosition = Player.Local.Controller.EyePosition;
-		var inRange = playerPosition.Distance( WorldPosition ) <= TvRange;
+		var playerDistance = playerPosition.Distance( WorldPosition );
+
+		if ( RequireLineOfSight )
+		{
+			// Only do raycast check if we're within basic distance range
+			if ( playerDistance <= TvRange )
+			{
+				// Perform raycast from player to TV to check for obstacles
+				var originPos = WorldPosition + WorldRotation * (Vector3.Up * 30 * WorldScale.z) + WorldRotation * Vector3.Forward * 5;
+				var direction = (originPos - playerPosition).Normal;
+
+				var trace = Scene.Trace.Ray( new Ray( playerPosition, direction ), TvRange )
+					.WithTag( "solid" )
+					.WithoutTags( Constants.PlayerTag )
+					.Run();
+
+				var isVisible = trace.GameObject == GameObject;
+
+				switch ( _isCurrentlyPlaying )
+				{
+					case false when playerDistance <= TvRange && isVisible && HasVideoContent():
+						StartPlayback();
+						break;
+					case true when playerDistance > TvRange || !isVisible:
+						StopPlayback();
+						break;
+				}
+			}
+			else if ( _isCurrentlyPlaying )
+			{
+				StopPlayback();
+			}
+
+			return;
+		}
 
 		switch ( _isCurrentlyPlaying )
 		{
-			case false when inRange && HasVideoContent():
+			case false when playerDistance <= TvRange && HasVideoContent():
 				StartPlayback();
 				break;
-			case true when !inRange:
+			case true when playerDistance > TvRange:
 				StopPlayback();
 				break;
 		}

--- a/game/Code/UI/Menus/PauseMenu/Components/Settings/MiscellaneousSettings.razor
+++ b/game/Code/UI/Menus/PauseMenu/Components/Settings/MiscellaneousSettings.razor
@@ -58,6 +58,13 @@
 		                              )/>
 	</div>
 
+	<div class="flex gap-2">
+		<p class="text-base">#settings.misc.tv_line_of_sight</p>
+		<SwitchControl Value="@( bool.Parse(ConsoleSystem.GetValue( "dx_tv_line_of_sight", "false")) )"
+		               OnValueChanged=@( ( bool value ) => { ConsoleSystem.SetValue( "dx_tv_line_of_sight", value ); }
+		                              )/>
+	</div>
+
 
 
 </root>

--- a/game/Code/UI/Menus/PauseMenu/Components/Settings/Settings.razor
+++ b/game/Code/UI/Menus/PauseMenu/Components/Settings/Settings.razor
@@ -10,7 +10,7 @@
 		</h1>
 	</div>
 	
-	<div class="flex gap-2 m-2">
+	<div class="settings-tabs flex gap-2 m-2">
 		<button class="btn btn-primary text-bold" href="/settings/general" >#settings.general</button>
 		<button class="btn btn-primary text-bold" href="/settings/graphics" >#settings.graphics</button>
 		<button class="btn btn-primary text-bold" href="/settings/performance" >#settings.performance</button>

--- a/game/Code/UI/Menus/PauseMenu/Components/Settings/Settings.razor.scss
+++ b/game/Code/UI/Menus/PauseMenu/Components/Settings/Settings.razor.scss
@@ -7,6 +7,15 @@ Settings {
   display: flex;
   flex-direction: column;
 
+  .settings-tabs {
+    flex-wrap: wrap;
+
+    .btn {
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+  }
+
   .navigator-body {
     flex-grow: 1;
 

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -1562,6 +1562,7 @@
   "settings.misc.civilian_clothing": "Civilian Job Clothing: ",
   "settings.misc.radio_distance": "Radio Distance: ",
   "settings.misc.radio_autoplay": "Autoplay Radios: ",
+  "settings.misc.tv_line_of_sight": "TV Line of Sight: ",
   "settings.misc.clothing_note": "The above setting will take effect for each player after their next respawn.",
   "inventory.title": "Inventory",
   "inventory.items": "{0} items",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -1559,6 +1559,7 @@
   "settings.misc.civilian_clothing": "Vêtements civils : ",
   "settings.misc.radio_distance": "Distance radio : ",
   "settings.misc.radio_autoplay": "Lecture auto des radios : ",
+  "settings.misc.tv_line_of_sight": "Visibilité TV : ",
   "settings.misc.clothing_note": "Le réglage prendra effet après réapparition.",
   "inventory.titles": "Inventaire",
   "inventory.items": "{0} objets",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -1561,6 +1561,7 @@
   "settings.misc.civilian_clothing": "시민 직업 의상: ",
   "settings.misc.radio_distance": "라디오 거리: ",
   "settings.misc.radio_autoplay": "라디오 자동 재생: ",
+  "settings.misc.tv_line_of_sight": "TV 시야 확인: ",
   "settings.misc.clothing_note": "위 설정은 각 플레이어가 다음 리스폰 후 적용됩니다.",
   "inventory.title": "인벤토리",
   "inventory.items": "{0}개 아이템",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -1561,6 +1561,7 @@
   "settings.misc.civilian_clothing": "Ubrania pracy cywila: ",
   "settings.misc.radio_distance": "Odległość radia: ",
   "settings.misc.radio_autoplay": "Automatyczne odtwarzanie radia: ",
+  "settings.misc.tv_line_of_sight": "Widoczność TV: ",
   "settings.misc.clothing_note": "Powyższe ustawienie zacznie obowiązywać dla każdego gracza po kolejnym odrodzeniu.",
   "inventory.title": "Ekwipunek",
   "inventory.items": "{0} przedmiotów",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -1559,6 +1559,7 @@
   "settings.misc.civilian_clothing": "Одежда гражданских: ",
   "settings.misc.radio_distance": "Дистанция радио: ",
   "settings.misc.radio_autoplay": "Автовоспроизведение радио: ",
+  "settings.misc.tv_line_of_sight": "Прямая видимость TV: ",
   "settings.misc.clothing_note": "Настройка одежды применится после возрождения.",
   "inventory.titles": "Инвентарь",
   "inventory.items": "{0} предм.",


### PR DESCRIPTION
## Summary
- Remove the line-of-sight raycast check that stopped TV playback whenever props, walls, or the player blocked the screen
- Playback now continues as long as the player stays within `dx_tv_range`, so audio keeps playing while moving around a shop or home
- Prevents YouTube embed reloads that restarted entire playlists after brief visibility loss

we dont hear sound of tv but just tv it strated 

https://github.com/user-attachments/assets/42f9550f-80fc-44c0-8b31-65a51f7df904

Closes #58 