### PR TITLE
Fix: prop scale rejected at exact 0.3 minimum boundary (#99)

### DIFF
--- a/game/Code/Construct/Constructs/Prop/PropDefinition.cs
+++ b/game/Code/Construct/Constructs/Prop/PropDefinition.cs
@@ -7,6 +7,7 @@ public class PropDefinition() : ConstructDefinition<Prop, PropData>
 
 	public const float MinPropScale = 0.3f;
 	public const float MaxPropScale = 2f;
+	public const float ScaleEpsilon = 0.0001f;
 	public const float MinFadingDoorDuration = 1.5f;
 	public const float MaxFadingDoorDuration = 60f;
 	public const float MinPropFriction = 0.02f;
@@ -23,10 +24,11 @@ public class PropDefinition() : ConstructDefinition<Prop, PropData>
 			return ConstructDataValidationResult.Failure( "Model path cannot be empty" );
 		}
 
-		// Validate scale bounds
-		if ( data.Scale.x < MinPropScale || data.Scale.x > MaxPropScale ||
-		     data.Scale.y < MinPropScale || data.Scale.y > MaxPropScale ||
-		     data.Scale.z < MinPropScale || data.Scale.z > MaxPropScale )
+		// Validate scale bounds (epsilon-tolerant so UI-driven values that land a hair outside the
+		// exact boundary due to float imprecision, e.g. 0.3, aren't incorrectly rejected)
+		if ( data.Scale.x < MinPropScale - ScaleEpsilon || data.Scale.x > MaxPropScale + ScaleEpsilon ||
+		     data.Scale.y < MinPropScale - ScaleEpsilon || data.Scale.y > MaxPropScale + ScaleEpsilon ||
+		     data.Scale.z < MinPropScale - ScaleEpsilon || data.Scale.z > MaxPropScale + ScaleEpsilon )
 		{
 			return ConstructDataValidationResult.Failure( $"Scale values must be between {MinPropScale} and {MaxPropScale}" );
 		}

--- a/game/Code/Equipment/Tool/Tools/ScaleTool.cs
+++ b/game/Code/Equipment/Tool/Tools/ScaleTool.cs
@@ -46,10 +46,10 @@ public class ScaleTool : BaseTool
 			return false;
 		}
 
-		// Validate scale limits
-		if ( x < PropDefinition.MinPropScale || x > PropDefinition.MaxPropScale ||
-		     y < PropDefinition.MinPropScale || y > PropDefinition.MaxPropScale ||
-		     z < PropDefinition.MinPropScale || z > PropDefinition.MaxPropScale )
+		// Validate scale limits (epsilon-tolerant, see PropDefinition.ScaleEpsilon)
+		if ( x < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || x > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon ||
+		     y < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || y > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon ||
+		     z < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || z > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon )
 		{
 			Notify.Error( $"Scale must be between {PropDefinition.MinPropScale} and {PropDefinition.MaxPropScale}" );
 			return false;
@@ -92,8 +92,9 @@ public class ScaleTool : BaseTool
 		}
 		else
 		{
-			// Validate factor scaling limits
-			if ( ScaleFactor is < PropDefinition.MinPropScale or > PropDefinition.MaxPropScale )
+			// Validate factor scaling limits (epsilon-tolerant, see PropDefinition.ScaleEpsilon)
+			if ( ScaleFactor < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon ||
+			     ScaleFactor > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon )
 			{
 				Notify.Error( $"Scale must be between {PropDefinition.MinPropScale} and {PropDefinition.MaxPropScale}" );
 				return;

--- a/game/Code/Equipment/Tool/Tools/ScaleTool.cs
+++ b/game/Code/Equipment/Tool/Tools/ScaleTool.cs
@@ -55,6 +55,11 @@ public class ScaleTool : BaseTool
 			return false;
 		}
 
+		// Snap values within epsilon of the boundary back onto it, so nothing slightly out-of-range is stored
+		x = Math.Clamp( x, PropDefinition.MinPropScale, PropDefinition.MaxPropScale );
+		y = Math.Clamp( y, PropDefinition.MinPropScale, PropDefinition.MaxPropScale );
+		z = Math.Clamp( z, PropDefinition.MinPropScale, PropDefinition.MaxPropScale );
+
 		scaleValues = new Vector3( x, y, z );
 		return true;
 	}
@@ -100,8 +105,11 @@ public class ScaleTool : BaseTool
 				return;
 			}
 
+			// Snap values within epsilon of the boundary back onto it, so nothing slightly out-of-range is stored
+			var clampedFactor = Math.Clamp( ScaleFactor, PropDefinition.MinPropScale, PropDefinition.MaxPropScale );
+
 			// Apply factor scaling
-			scaleValues = Vector3.One * ScaleFactor;
+			scaleValues = Vector3.One * clampedFactor;
 		}
 
 		if ( !Scale( targetObject, scaleValues ) )

--- a/game/Code/GameManager.cs
+++ b/game/Code/GameManager.cs
@@ -861,10 +861,10 @@ public class GameManager : SingletonComponent<GameManager>, IGameEvents, IConfig
 			return;
 		}
 
-		// Server-side scale validation
-		if ( scaleValues.x < PropDefinition.MinPropScale || scaleValues.x > PropDefinition.MaxPropScale ||
-		     scaleValues.y < PropDefinition.MinPropScale || scaleValues.y > PropDefinition.MaxPropScale ||
-		     scaleValues.z < PropDefinition.MinPropScale || scaleValues.z > PropDefinition.MaxPropScale )
+		// Server-side scale validation (epsilon-tolerant, see PropDefinition.ScaleEpsilon)
+		if ( scaleValues.x < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || scaleValues.x > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon ||
+		     scaleValues.y < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || scaleValues.y > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon ||
+		     scaleValues.z < PropDefinition.MinPropScale - PropDefinition.ScaleEpsilon || scaleValues.z > PropDefinition.MaxPropScale + PropDefinition.ScaleEpsilon )
 		{
 			player.Error( "#notify.scale.invalid_target" );
 			return;

--- a/game/Code/GameManager.cs
+++ b/game/Code/GameManager.cs
@@ -870,6 +870,13 @@ public class GameManager : SingletonComponent<GameManager>, IGameEvents, IConfig
 			return;
 		}
 
+		// Snap values within epsilon of the boundary back onto it, so nothing slightly out-of-range is stored
+		scaleValues = new Vector3(
+			Math.Clamp( scaleValues.x, PropDefinition.MinPropScale, PropDefinition.MaxPropScale ),
+			Math.Clamp( scaleValues.y, PropDefinition.MinPropScale, PropDefinition.MaxPropScale ),
+			Math.Clamp( scaleValues.z, PropDefinition.MinPropScale, PropDefinition.MaxPropScale )
+		);
+
 		// Apply the scaling directly - unified approach for all
 		entity.ApplyScaleOwner( scaleValues );
 	}

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/DefaultToolInspector.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/DefaultToolInspector.razor
@@ -43,6 +43,10 @@
 								OnTextEdited=@( ( string value ) => {
 									if ( float.TryParse( value, out var floatValue ) )
 									{
+										if ( range != null )
+										{
+											floatValue = Math.Clamp( floatValue, range.Min, range.Max );
+										}
 										property.SetValue( floatValue );
 									}
 								} )/>

--- a/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/DefaultToolInspector.razor
+++ b/game/Code/UI/Menus/BuildMenu/Components/Tool/Inspector/DefaultToolInspector.razor
@@ -36,17 +36,13 @@
 							               OnValueChanged=@( ( float value ) => { property.SetValue( value ); } )
 							               ShowTextEntry=@( false )
 							               style="flex: 1; min-width: 50px;"/>
-							<TextEntry 
+							<TextEntry
 								Value="@( property.GetValue<float>().ToString("F2") )"
 								class="text-tertiary"
 								style="width: 60px; flex-shrink: 0;"
-								OnTextEdited=@( ( string value ) => { 
+								OnTextEdited=@( ( string value ) => {
 									if ( float.TryParse( value, out var floatValue ) )
 									{
-										if ( range != null )
-										{
-											floatValue = Math.Clamp( floatValue, range.Min, range.Max );
-										}
 										property.SetValue( floatValue );
 									}
 								} )/>


### PR DESCRIPTION
## Summary
Fixes #99
- Root cause: four separate scale-boundary checks (ScaleTool.cs x2, PropDefinition.cs, GameManager.cs) compared against the MinPropScale/MaxPropScale constants with a strict `<`/`>`. A UI-driven value landing marginally below 0.3 due to float imprecision (slider drag, text round-trip) was hard rejected.