### PR TITLE
fix(wire): show label context regardless of equipped tool (#100)

### DIFF
--- a/game/Code/Construct/Constructs/Wire/ButtonWire/ButtonWire.cs
+++ b/game/Code/Construct/Constructs/Wire/ButtonWire/ButtonWire.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 namespace Dxura.RP.Game.Wire;
 
 [Title( "Button" )]
@@ -18,6 +18,8 @@ public class ButtonWire() : BaseWireConstruct( ConstructType.ButtonWire ), Compo
 	private float Out { get; set; }
 
 	public override string Name => "Button";
+
+	public override bool ShouldShow() => !string.IsNullOrWhiteSpace( DisplayText );
 
 	[Property]
 	private float PressDepth { get; set; } = 2.0f;

--- a/game/Code/Construct/Constructs/Wire/ScreenWire/ScreenWire.cs
+++ b/game/Code/Construct/Constructs/Wire/ScreenWire/ScreenWire.cs
@@ -21,6 +21,9 @@ public class ScreenWire() : BaseWireConstruct( ConstructType.ScreenWire ), IWire
 
 	public override string Name => "Screen";
 
+	// The label is already drawn as the header text on the screen itself, so skip the floating context bubble.
+	public override string? DisplayText => null;
+
 	private DisplayMode _mode = DisplayMode.Text;
 
 	private bool _playerWithinRaycast;

--- a/game/Code/Construct/Wire/BaseWireConstruct.cs
+++ b/game/Code/Construct/Wire/BaseWireConstruct.cs
@@ -1,3 +1,4 @@
+using Dxura.RP.Game.Tools;
 using Dxura.RP.Game.UI;
 namespace Dxura.RP.Game.Wire;
 
@@ -16,7 +17,7 @@ public abstract class BaseWireConstruct( ConstructType type ) : BaseConstruct( t
 	public Vector3 ContextPosition => WorldPosition + Vector3.Up * 6f;
 	public bool LookOpacity => false;
 	public float ContextMaxDistance => 100f;
-	public virtual bool ShouldShow() => !string.IsNullOrWhiteSpace( DisplayText );
+	public virtual bool ShouldShow() => (WireTool.IsDeployed || WireLabelerTool.IsDeployed) && !string.IsNullOrWhiteSpace( DisplayText );
 
 	protected override void OnStart()
 	{

--- a/game/Code/Construct/Wire/BaseWireConstruct.cs
+++ b/game/Code/Construct/Wire/BaseWireConstruct.cs
@@ -1,4 +1,3 @@
-using Dxura.RP.Game.Tools;
 using Dxura.RP.Game.UI;
 namespace Dxura.RP.Game.Wire;
 
@@ -13,11 +12,11 @@ public abstract class BaseWireConstruct( ConstructType type ) : BaseConstruct( t
 
 	protected string? WireLabel => Data is IWireLabelData labelData ? labelData.Label : null;
 
-	public string? DisplayText => string.IsNullOrWhiteSpace( WireLabel ) ? null : WireLabel!.Trim();
+	public virtual string? DisplayText => string.IsNullOrWhiteSpace( WireLabel ) ? null : WireLabel!.Trim();
 	public Vector3 ContextPosition => WorldPosition + Vector3.Up * 6f;
 	public bool LookOpacity => false;
 	public float ContextMaxDistance => 100f;
-	public bool ShouldShow() => (WireTool.IsDeployed || WireLabelerTool.IsDeployed) && DisplayText != null;
+	public bool ShouldShow() => DisplayText != null;
 
 	protected override void OnStart()
 	{

--- a/game/Code/Construct/Wire/BaseWireConstruct.cs
+++ b/game/Code/Construct/Wire/BaseWireConstruct.cs
@@ -16,7 +16,7 @@ public abstract class BaseWireConstruct( ConstructType type ) : BaseConstruct( t
 	public Vector3 ContextPosition => WorldPosition + Vector3.Up * 6f;
 	public bool LookOpacity => false;
 	public float ContextMaxDistance => 100f;
-	public bool ShouldShow() => DisplayText != null;
+	public virtual bool ShouldShow() => !string.IsNullOrWhiteSpace( DisplayText );
 
 	protected override void OnStart()
 	{


### PR DESCRIPTION
## Summary
- Wire labels only showed while the Wire Tool or Labeler was equipped, so old dupes (and labels set via other tools) never displayed their context bubble.
- `ShouldShow()` now depends only on whether a custom label is set, independent of the currently equipped tool.
- `ScreenWire` overrides `DisplayText` to suppress the bubble, since its label is already rendered as the header text on the screen itself.

Fixes #100