### PR TITLE
fix(equipment): fit dropped weapon collider to world model bounds (#104)

### DIFF
--- a/game/Code/Equipment/DroppedEquipment.cs
+++ b/game/Code/Equipment/DroppedEquipment.cs
@@ -149,12 +149,13 @@ public class DroppedEquipment : Component, Component.IPressable
 		droppedWeapon.PrefabPath = dto.PrefabPath();
 		droppedWeapon.MarketItemId = marketItemId != Guid.Empty ? marketItemId : heldWeapon?.MarketItemId ?? Guid.Empty;
 
+		var model = dto.GetWorldModel();
 		var renderer = go.Components.Create<ModelRenderer>();
-		renderer.Model = dto.GetWorldModel();
+		renderer.Model = model;
 
 		var collider = go.Components.Create<BoxCollider>();
-		collider.Scale = heldWeapon?.DroppedSize ?? new Vector3( 8, 2, 8 );
-		collider.Center = heldWeapon?.DroppedCenter ?? default;
+		collider.Scale = model?.Bounds.Size ?? new Vector3( 8, 2, 8 );
+		collider.Center = model?.Bounds.Center ?? default;
 
 		droppedWeapon.Rigidbody = go.Components.Create<Rigidbody>();
 

--- a/game/Code/Equipment/DroppedEquipment.cs
+++ b/game/Code/Equipment/DroppedEquipment.cs
@@ -154,8 +154,16 @@ public class DroppedEquipment : Component, Component.IPressable
 		renderer.Model = model;
 
 		var collider = go.Components.Create<BoxCollider>();
-		collider.Scale = model?.Bounds.Size ?? new Vector3( 8, 2, 8 );
-		collider.Center = model?.Bounds.Center ?? default;
+		if ( model.IsValid() && model.Bounds.Size.Length > 0.1f )
+		{
+			collider.Scale = model.Bounds.Size;
+			collider.Center = model.Bounds.Center;
+		}
+		else
+		{
+			collider.Scale = heldWeapon?.DroppedSize ?? new Vector3( 8, 2, 8 );
+			collider.Center = heldWeapon?.DroppedCenter ?? default;
+		}
 
 		droppedWeapon.Rigidbody = go.Components.Create<Rigidbody>();
 


### PR DESCRIPTION
## Summary

Fixes the misaligned hitboxes on dropped weapons reported in #104: the collider sat about half a gun-height off the model.

`DroppedEquipment.CreateHost` created a hardcoded `8x2x8` `BoxCollider` centered at the GameObject origin. Weapon world models are not centered at the origin (e.g. the spaghelli M4 world model spans `z: 0.1 -> 7.9` and `x: -20.3 -> 20.2`), so the box was both too small and vertically offset.

The collider is now sized and centered from the world model's actual bounds, with the previous `8x2x8` box kept only as a fallback when no world model is available.

Closes #104