### PR TITLE
fix(playermodels) : custom model dresser artifacts and preview framing (#109)

### DIFF
--- a/game/Code/Player/Player.Body.cs
+++ b/game/Code/Player/Player.Body.cs
@@ -33,6 +33,8 @@ public partial class Player
 	public Vector3 DamageTakenPosition { get; set; }
 	public Vector3 DamageTakenForce { get; set; }
 
+	private int _clothingApplyVersion;
+
 	private void OnStartBody()
 	{
 		NamePlate.Enabled = !IsLocalPlayer && !GameManager.IsHeadless;
@@ -117,34 +119,68 @@ public partial class Player
 	/// </summary>
 	public void ApplyClothing()
 	{
-		if ( !Renderer.IsValid() || !Job.IsValid() || !Dresser.IsValid() || GameManager.IsHeadless )
+		if ( !Renderer.IsValid() || !Job.IsValid() || GameManager.IsHeadless )
 		{
 			return;
 		}
 
+		var applyVersion = ++_clothingApplyVersion;
+
+		if ( !Job.SupportsCitizenClothing() )
+		{
+			if ( Dresser.IsValid() )
+			{
+				Dresser.Clothing.Clear();
+				Dresser.Enabled = false;
+			}
+
+			CleanupDresserClothing();
+
+			if ( !Job.HasCloudModel() )
+			{
+				ApplyUndressedModel( Job.GetPrimaryModel() );
+				return;
+			}
+
+			_ = ApplyUndressedModelAsync( applyVersion );
+			return;
+		}
+
+		if ( !Dresser.IsValid() )
+		{
+			return;
+		}
+
+		Dresser.Enabled = true;
+
 		// 1: Apply model
 		Renderer.Model = Job.GetPrimaryModel();
 
-		// 2: Build and apply clothing
+		// 2: Build and apply citizen clothing
 		var includeJobClothing = DxCivilianJobClothing || !Job.IsInGroup( "0802e49f-43ba-5bf2-adb0-933b150f0156" );
 		Dresser.Clothing.Clear();
 		Dresser.Clothing.AddRange( Job.BuildClothing( this, includeJobClothing ).Clothing );
 
-		_ = ApplyClothingAsync();
+		_ = ApplyClothingAsync( applyVersion );
 	}
 
-	public async Task ApplyClothingAsync()
+	private async Task ApplyClothingAsync( int applyVersion )
 	{
 		// Wait for a fixed update so stuff is ready
 		await Task.FixedUpdate();
 
-		if ( !GameObject.IsValid() || !Dresser.IsValid() )
+		if ( !GameObject.IsValid() || !Dresser.IsValid() || applyVersion != _clothingApplyVersion )
 		{
 			return;
 		}
 
 		// Resolve cloud model (may need to download/mount the package)
 		var model = await Job.GetPrimaryModelAsync();
+
+		if ( !GameObject.IsValid() || !Dresser.IsValid() || applyVersion != _clothingApplyVersion )
+		{
+			return;
+		}
 
 		if ( Renderer.IsValid() )
 		{
@@ -153,7 +189,22 @@ public partial class Player
 
 		await Dresser.Apply();
 
-		if ( !GameObject.IsValid() || !ModelHitboxes.IsValid() )
+		if ( !GameObject.IsValid() )
+		{
+			return;
+		}
+
+		if ( applyVersion != _clothingApplyVersion )
+		{
+			if ( !Job.SupportsCitizenClothing() )
+			{
+				CleanupDresserClothing();
+			}
+
+			return;
+		}
+
+		if ( !ModelHitboxes.IsValid() )
 		{
 			return;
 		}
@@ -161,10 +212,81 @@ public partial class Player
 		ModelHitboxes.Rebuild();
 	}
 
+	private async Task ApplyUndressedModelAsync( int applyVersion )
+	{
+		await Task.FixedUpdate();
+
+		if ( !GameObject.IsValid() || applyVersion != _clothingApplyVersion )
+		{
+			return;
+		}
+
+		var model = await Job.GetPrimaryModelAsync();
+
+		if ( !GameObject.IsValid() || applyVersion != _clothingApplyVersion )
+		{
+			return;
+		}
+
+		ApplyUndressedModel( model );
+	}
+
+	private void ApplyUndressedModel( Model model )
+	{
+		if ( Dresser.IsValid() )
+		{
+			Dresser.Clothing.Clear();
+			Dresser.Enabled = false;
+		}
+
+		CleanupDresserClothing();
+
+		if ( Renderer.IsValid() )
+		{
+			Renderer.Model = model;
+		}
+
+		if ( ModelHitboxes.IsValid() )
+		{
+			ModelHitboxes.Rebuild();
+		}
+	}
+
+	private void CleanupDresserClothing()
+	{
+		if ( !BodyRoot.IsValid() )
+		{
+			return;
+		}
+
+		foreach ( var skinnedRenderer in BodyRoot.GetComponentsInChildren<SkinnedModelRenderer>( true ).ToArray() )
+		{
+			if ( skinnedRenderer == Renderer || skinnedRenderer == EmoteRenderer )
+			{
+				continue;
+			}
+
+			if ( !skinnedRenderer.GameObject.Name.StartsWith( "Clothing - ", StringComparison.Ordinal ) )
+			{
+				continue;
+			}
+
+			skinnedRenderer.GameObject.Destroy();
+		}
+	}
+
 	public void ClearClothing()
 	{
 		if ( !Renderer.IsValid() )
 		{
+			return;
+		}
+
+		CleanupDresserClothing();
+
+		if ( !Job.IsValid() || !Job.SupportsCitizenClothing() )
+		{
+			Renderer.Enabled = false;
 			return;
 		}
 

--- a/game/Code/UI/Components/JobCardPlayerModel.razor
+++ b/game/Code/UI/Components/JobCardPlayerModel.razor
@@ -69,7 +69,13 @@ else if ( Job.IsValid() )
 			return Texture.Transparent;
 
 		return ThumbnailCache.GetCharacterPortrait( key, Job,
-			r => Job.BuildClothing().Apply( r ) );
+			r =>
+			{
+				if ( Job.SupportsCitizenClothing() )
+				{
+					Job.BuildClothing().Apply( r );
+				}
+			} );
 	}
 
 	private string BuildSignature()

--- a/game/Code/UI/Components/PlayerRenderPreview.razor
+++ b/game/Code/UI/Components/PlayerRenderPreview.razor
@@ -40,6 +40,7 @@
 	private float _yawVelocity;
 	private bool _isDragging;
 	private Vector2 _lastMousePosition;
+	private int _previewVersion;
 
 	public GameModeJobDto? Job { get; set; }
 	public Player? Player { get; set; }
@@ -168,46 +169,64 @@
 		if ( Player != null )
 		{
 			renderer.Model = Player.GetPrimaryModel();
-			Player.Job.BuildClothing( Player ).Apply( renderer );
+			if ( Player.Job.SupportsCitizenClothing() )
+			{
+				Player.Job.BuildClothing( Player ).Apply( renderer );
+			}
 			return;
 		}
 
-		if ( Job!.HasCloudModel() )
+		var job = Job!;
+
+		if ( job.HasCloudModel() )
 		{
 			renderer.Enabled = false;
-			_ = ApplyCloudModelAsync( Job, renderer );
+			_ = ApplyCloudModelAsync( job, renderer );
 			return;
 		}
 
-		renderer.Model = Job.GetPrimaryModel();
-		Job.BuildClothing().Apply( renderer );
+		renderer.Model = job.GetPrimaryModel();
+		if ( job.SupportsCitizenClothing() )
+		{
+			job.BuildClothing().Apply( renderer );
+		}
 	}
 
-	private void CenterPreview( SkinnedModelRenderer renderer ) =>
-		CenterPreview( renderer.Bounds.Size.LengthSquared > 1f ? renderer.Bounds : renderer.Model.Bounds );
-
-	private void CenterPreview( BBox bounds )
+	private void CenterPreview( SkinnedModelRenderer renderer )
 	{
-		var localCenter = bounds.Center - PreviewOrigin;
-		var localMins = bounds.Mins - PreviewOrigin;
+		if ( !_body.IsValid() || !_pivot.IsValid() )
+		{
+			return;
+		}
+
+		var useModelBounds = renderer.Model.IsValid() && renderer.Model.Bounds.Size.LengthSquared > 1f;
+		var bounds = useModelBounds ? renderer.Model.Bounds : renderer.Bounds;
+		var worldBounds = !useModelBounds;
+		CenterPreview( bounds, worldBounds );
+	}
+
+	private void CenterPreview( BBox bounds, bool worldBounds )
+	{
+		var localCenter = worldBounds ? bounds.Center - PreviewOrigin : bounds.Center;
+		var localMins = worldBounds ? bounds.Mins - PreviewOrigin : bounds.Mins;
+		var rawWidth = MathF.Max( MathF.Max( bounds.Size.x, bounds.Size.y ), 18f );
+		var rawHeight = MathF.Max( bounds.Size.z, 48f );
 
 		if ( Player != null )
 		{
-			var width = MathF.Max( MathF.Max( bounds.Size.x, bounds.Size.y ), 18f );
-			var height = MathF.Max( bounds.Size.z, 48f );
+			var width = MathF.Min( rawWidth, 58f );
+			var height = MathF.Min( rawHeight, 84f );
 
 			_modelSize = new Vector3( width, width, height );
 			_body!.LocalPosition = new Vector3( -localCenter.x, -localCenter.y, -localMins.z );
 			_focusPoint = PreviewOrigin + Vector3.Up * Math.Clamp( height * 0.58f, 22f, height * 0.72f );
-			_fitDistance = Math.Clamp( MathF.Max( height * 0.62f, width * 1.3f ), 44f, 96f );
+			_fitDistance = Math.Clamp( MathF.Max( height * 0.68f, width * 1.28f ), 44f, 96f );
 			_zoomOffset = 0f;
 			_minDistance = Math.Clamp( _fitDistance * 0.72f, 36f, 84f );
 			_maxDistance = Math.Clamp( _fitDistance * 1.45f, 60f, 144f );
 		}
 		else
 		{
-			var rawWidth = MathF.Max( MathF.Max( bounds.Size.x, bounds.Size.y ), 18f );
-			var rawHeight = MathF.Max( bounds.Size.z, 48f );
 			var width = MathF.Min( rawWidth, 46f );
 			var height = MathF.Min( rawHeight, 76f );
 
@@ -282,6 +301,7 @@
 
 	private void RebuildPreview()
 	{
+		var previewVersion = ++_previewVersion;
 		DestroyPreviewObjects();
 		EnsureScene();
 		if ( _scene == null || !_scene.IsValid() )
@@ -305,6 +325,22 @@
 			PopulatePreview( renderer );
 			EnsureLight();
 			if ( renderer.Model.IsValid() ) CenterPreview( renderer );
+			_ = CenterPreviewAsync( renderer, previewVersion );
+		}
+	}
+
+	private async Task CenterPreviewAsync( SkinnedModelRenderer renderer, int previewVersion )
+	{
+		await Task.FixedUpdate();
+
+		if ( previewVersion != _previewVersion || !renderer.IsValid() || _scene == null || !_scene.IsValid() )
+		{
+			return;
+		}
+
+		using ( _scene.Push() )
+		{
+			CenterPreview( renderer );
 		}
 	}
 
@@ -389,7 +425,7 @@
 		{
 			renderer.Model = model;
 			renderer.Enabled = true;
-			CenterPreview( model.Bounds );
+			CenterPreview( renderer );
 		}
 	}
 }

--- a/game/Code/Utilities/Resource/GameModeJobDtoExtensions.cs
+++ b/game/Code/Utilities/Resource/GameModeJobDtoExtensions.cs
@@ -108,9 +108,23 @@ public static class GameModeJobDtoExtensions
 		return !string.IsNullOrWhiteSpace( modelPath ) && IsCloudIdent( modelPath );
 	}
 
+	public static bool SupportsCitizenClothing( this GameModeJobDto? job )
+	{
+		var modelPath = ResolveModelPath( job );
+		return !IsCloudIdent( modelPath ) && IsCitizenModelPath( modelPath );
+	}
+
 	private static bool IsCloudIdent( string path )
 	{
 		return !path.Contains( '/' ) && path.Contains( '.' );
+	}
+
+	private static bool IsCitizenModelPath( string path )
+	{
+		path = path.Replace( '\\', '/' ).Trim();
+
+		return path.StartsWith( "models/citizen/", StringComparison.OrdinalIgnoreCase )
+		       || path.StartsWith( "models/citizen_human/", StringComparison.OrdinalIgnoreCase );
 	}
 
 	public static string FormatPlayerSlots( this GameModeJobDto? job, int currentPlayers )
@@ -229,7 +243,7 @@ public static class GameModeJobDtoExtensions
 	{
 		var clothing = new ClothingContainer();
 
-		if ( !job.HasCloudModel() )
+		if ( job.SupportsCitizenClothing() )
 		{
 			var source = avatarSource ?? (Player.Local.IsValid() ? Player.Local : null);
 			var avatarData = source?.Network.Owner?.GetUserData( "avatar" );
@@ -250,6 +264,12 @@ public static class GameModeJobDtoExtensions
 	public static ClothingContainer BuildClothing( this Player player )
 	{
 		var clothing = new ClothingContainer();
+
+		if ( player.Job.IsValid() && !player.Job.SupportsCitizenClothing() )
+		{
+			return clothing;
+		}
+
 		var avatarData = player.Network.Owner?.GetUserData( "avatar" );
 
 		if ( !string.IsNullOrWhiteSpace( avatarData ) )


### PR DESCRIPTION
## Root Cause
Custom/cloud job models were still going through the s&box `Dresser` pipeline. The Dresser is intended for citizen/human models, but our player clothing code still cleared and applied it even when the active job model was custom.

Because of that, Dresser-generated renderers from the human model could linger under the player body. These generated objects are named `Clothing - ...`, and in some cases they left visible human body parts, especially legs, inside custom models.

## Fix
This PR adds an explicit `SupportsCitizenClothing()` check so citizen clothing is only applied to supported models:

- `models/citizen/...`
- `models/citizen_human/...`

For custom/cloud models, we now:
- skip `Dresser.Apply()`
- clear and disable the Dresser
- remove lingering Dresser-generated `Clothing - ...` renderers
- apply the same citizen-clothing guard in job/player previews

This keeps the normal citizen clothing behavior intact while preventing human legs/body parts from leaking into custom models.

<img width="1278" height="719" alt="image" src="https://github.com/user-attachments/assets/7e2604ea-a616-485c-aa5e-a3403cfa796a" />
<img width="1162" height="619" alt="image" src="https://github.com/user-attachments/assets/88aebe76-6f50-470c-af02-a5f698048362" />
<img width="1142" height="613" alt="image" src="https://github.com/user-attachments/assets/457763be-8781-4274-b67e-b27be476485e" />


Fixes #109 