### PR TITLE
fix(tabjobs): Refactor logic compare jobs

### DIFF
--- a/game/Code/Chat/Commands/JobCommand.cs
+++ b/game/Code/Chat/Commands/JobCommand.cs
@@ -59,7 +59,7 @@ public class JobCommand : ICommand
 			return;
 		}
 
-		if ( caller.Job == job )
+		if ( caller.Job.IsSameJob( job ) )
 		{
 			return;
 		}
@@ -152,7 +152,7 @@ public class JobCommand : ICommand
 			return;
 		}
 
-		if ( targetPlayer.Job == job )
+		if ( targetPlayer.Job.IsSameJob( job ) )
 		{
 			caller.SendMessage( string.Format(
 				Language.GetPhrase( "command.job.already" ),

--- a/game/Code/Player/Player.State.cs
+++ b/game/Code/Player/Player.State.cs
@@ -208,7 +208,7 @@ public partial class Player : IDescription
 	{
 		Assert.True( Networking.IsHost );
 
-		if ( !job.IsValid() || Job == job )
+		if ( !job.IsValid() || Job.IsSameJob( job ) )
 		{
 			return;
 		}

--- a/game/Code/UI/Components/JobCardPlayerModel.razor
+++ b/game/Code/UI/Components/JobCardPlayerModel.razor
@@ -30,7 +30,7 @@ else if ( Job.IsValid() )
 	public GameModeJobDto? Job { get; set; }
 	public int Size { get; set; } = 56;
 
-	private bool IsCurrentJob => Job.IsValid() && Player.Local.IsValid() && Player.Local.Job == Job;
+	private bool IsCurrentJob => Job.IsValid() && Player.Local.IsValid() && Player.Local.Job.IsSameJob( Job );
 	private Color BorderColor => Job.ColorValue();
 
 	protected override int BuildHash()

--- a/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
@@ -16,7 +16,12 @@
 	var needsMorePlayTime = requiredPlayTime > currentPlayTime && !IgnoreJobRequirements;
 	var remainingPlayTime = requiredPlayTime - currentPlayTime;
 	var isCurrentJob = Player.Local.Job.IsSameJob( Job );
-	var canChange = !isCurrentJob && Job.Selectable && !needsMorePlayTime && !isFull;
+	var prerequisiteJobs = GameModeJobs.GetPrerequisiteJobs( Job );
+	var missingPrerequisite = !IgnoreJobRequirements
+	                          && prerequisiteJobs.Length > 0
+	                          && !prerequisiteJobs.Any( p => p.Id == Player.Local.Job?.Id )
+	                          && !isCurrentJob;
+	var canChange = !isCurrentJob && Job.Selectable && !needsMorePlayTime && !missingPrerequisite && !isFull;
 	var loadout = GetDisplayLoadout( Job ).ToList();
 	var visibleLoadout = loadout.Take( MaxVisibleLoadoutIcons ).ToList();
 	var hiddenLoadoutCount = loadout.Count - visibleLoadout.Count;
@@ -64,6 +69,12 @@
 				{
 					<div class="unlock-notice">
 						@( $"{Language.GetPhrase( "generic.unlocks" )} {TimeSpan.FromMinutes( remainingPlayTime ).Humanize( 1 )}" )
+					</div>
+				}
+				else if ( missingPrerequisite )
+				{
+					<div class="unlock-notice">
+						#notify.job.prerequisite
 					</div>
 				}
 

--- a/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
@@ -15,7 +15,7 @@
 	var currentPlayTime = (int)(Player.Local.PlayTime / 60f);
 	var needsMorePlayTime = requiredPlayTime > currentPlayTime && !IgnoreJobRequirements;
 	var remainingPlayTime = requiredPlayTime - currentPlayTime;
-	var isCurrentJob = Player.Local.Job == Job;
+	var isCurrentJob = Player.Local.Job.IsSameJob( Job );
 	var canChange = !isCurrentJob && Job.Selectable && !needsMorePlayTime && !isFull;
 	var loadout = GetDisplayLoadout( Job ).ToList();
 	var visibleLoadout = loadout.Take( MaxVisibleLoadoutIcons ).ToList();

--- a/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedJobPane.razor
@@ -63,7 +63,7 @@
 				@if ( needsMorePlayTime )
 				{
 					<div class="unlock-notice">
-						<span>#generic.unlocks</span> @TimeSpan.FromMinutes( remainingPlayTime ).Humanize( 1 )
+						@( $"{Language.GetPhrase( "generic.unlocks" )} {TimeSpan.FromMinutes( remainingPlayTime ).Humanize( 1 )}" )
 					</div>
 				}
 

--- a/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedPlayerPane.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/Components/SelectedPlayerPane.razor
@@ -15,7 +15,7 @@
 		var canTargetRank = RankSystem.CanLocalTarget( SelectedPlayer.SteamId );
 		var canDemote = Config.Current.Game.DemoteEnabled &&
 		                Player.Local.PlayTime >= Config.Current.Game.DemoteMinPlaytime &&
-		                SelectedPlayer.Job != GameModeJobs.Default &&
+		                !SelectedPlayer.Job.IsSameJob( GameModeJobs.Default ) &&
 		                SelectedPlayer.Job.Demotable;
 		var canJail = canTargetRank && RankSystem.HasLocalPermission( Permission.PlayerJail );
 		var canBan = canTargetRank && RankSystem.HasLocalPermission( Permission.PlayerBan );

--- a/game/Code/UI/Menus/TabMenu/Sections/JobTabMenuSection.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/JobTabMenuSection.razor
@@ -59,7 +59,7 @@
 									var jobPlayers = playersByJobId.GetValueOrDefault( job.Id ) ?? EmptyJobPlayers;
 									var currentPlayers = jobPlayers.Count;
 									var isFull = job.MaxCount > 0 && currentPlayers >= job.MaxCount;
-									var isCurrentJob = Player.Local.Job == job;
+									var isCurrentJob = Player.Local.Job.IsSameJob( job );
 									var isSelected = effectiveSelected == job;
 
 									<div class="job-card @( isSelected ? "selected" : "" ) @( isCurrentJob ? "current" : "" )"
@@ -172,13 +172,13 @@
 	private IEnumerable<GameModeJobDto> GetVisibleJobs()
 	{
 		return GameModeJobs.All
-			.Where( x => x.Selectable || x == Player.Local.Job )
+			.Where( x => x.Selectable || x.IsSameJob( Player.Local.Job ) )
 			.Where( job =>
 			{
 				var prerequisiteJobs = GameModeJobs.GetPrerequisiteJobs( job );
 				return prerequisiteJobs.Length == 0 ||
 				       prerequisiteJobs.Any( p => p.Id == Player.Local.Job?.Id ) ||
-				       job == Player.Local.Job;
+				       job.IsSameJob( Player.Local.Job );
 			} )
 			.OrderBy( x => x.GetGroup()?.Name ?? "zzzz" )
 			.ThenBy( x => x.DisplayName() );
@@ -189,7 +189,7 @@
 		if ( _selectedJob != null && visibleJobs.Contains( _selectedJob ) )
 			return _selectedJob;
 
-		return visibleJobs.FirstOrDefault( x => x == Player.Local.Job ) ?? visibleJobs.FirstOrDefault();
+		return visibleJobs.FirstOrDefault( x => x.IsSameJob( Player.Local.Job ) ) ?? visibleJobs.FirstOrDefault();
 	}
 
 	private static Guid GetGroupKey( Guid? groupId ) => groupId ?? Guid.Empty;

--- a/game/Code/UI/Menus/TabMenu/Sections/JobTabMenuSection.razor
+++ b/game/Code/UI/Menus/TabMenu/Sections/JobTabMenuSection.razor
@@ -173,13 +173,6 @@
 	{
 		return GameModeJobs.All
 			.Where( x => x.Selectable || x.IsSameJob( Player.Local.Job ) )
-			.Where( job =>
-			{
-				var prerequisiteJobs = GameModeJobs.GetPrerequisiteJobs( job );
-				return prerequisiteJobs.Length == 0 ||
-				       prerequisiteJobs.Any( p => p.Id == Player.Local.Job?.Id ) ||
-				       job.IsSameJob( Player.Local.Job );
-			} )
 			.OrderBy( x => x.GetGroup()?.Name ?? "zzzz" )
 			.ThenBy( x => x.DisplayName() );
 	}

--- a/game/Code/Utilities/GameUtils.cs
+++ b/game/Code/Utilities/GameUtils.cs
@@ -18,7 +18,7 @@ public static class GameUtils
 	/// </summary>
 	public static IEnumerable<Player> GetPlayersByJob( GameModeJobDto job )
 	{
-		return Players.Where( x => x.Job == job );
+		return Players.Where( x => x.Job.IsSameJob( job ) );
 	}
 
 	public static IEnumerable<Player> GetPlayersByJobTag( JobTag tag )

--- a/game/Code/Utilities/Resource/GameModeJobDtoExtensions.cs
+++ b/game/Code/Utilities/Resource/GameModeJobDtoExtensions.cs
@@ -143,6 +143,11 @@ public static class GameModeJobDtoExtensions
 		return job != null && job.Id != Guid.Empty && !string.IsNullOrWhiteSpace( job.Name );
 	}
 
+	public static bool IsSameJob( this GameModeJobDto? job, GameModeJobDto? other )
+	{
+		return job.IsValid() && other.IsValid() && job!.Id == other!.Id;
+	}
+
 	public static bool IsGovernmentRole( this GameModeJobDto? job )
 	{
 		return job.HasTag( JobTag.Government );
@@ -185,7 +190,7 @@ public static class GameModeJobDtoExtensions
 
 	public static bool AssignableTo( this GameModeJobDto job, Player player )
 	{
-		if ( player.Job == job )
+		if ( player.Job.IsSameJob( job ) )
 		{
 			return false;
 		}


### PR DESCRIPTION
This pull request refactors the way jobs are compared throughout the codebase by introducing and consistently using a new `IsSameJob` extension method for `GameModeJobDto` objects. This improves reliability and readability when checking if two jobs are the same, as it now compares jobs by their IDs rather than by reference or other properties. The change affects job assignment logic, UI components, and utility functions.

**Core logic improvements:**

* Added a new `IsSameJob` extension method to `GameModeJobDtoExtensions.cs` that compares jobs by their IDs and ensures both jobs are valid before comparison.
* Replaced all direct job comparisons (`==` or `!=`) with the new `IsSameJob` method in job assignment logic, including `JobCommand.cs`, `Player.State.cs`, and utility methods. [[1]](diffhunk://#diff-e5358c582777fad2e794942228d5960e78cedd10dfed11cca1c94180be0b5506L62-R62) [[2]](diffhunk://#diff-e5358c582777fad2e794942228d5960e78cedd10dfed11cca1c94180be0b5506L155-R155) [[3]](diffhunk://#diff-2b9a7a4c630d114f92e0b20968da6755e6d889fac609690255840e918f2211c9L211-R211) [[4]](diffhunk://#diff-9784f6c3e9b98bed367a59ba4914cbdaf80874a7b2553c46577f2c53e1fc6b81L188-R193) [[5]](diffhunk://#diff-a2461f9092fa2ddba5d3541dcac7bdc7bb3433963387c86f8be1987ad0bf63a5L21-R21)

**UI consistency:**

* Updated all UI components and menu sections to use `IsSameJob` for job equality checks, ensuring consistent behavior across job cards, selection panes, and job tab menus. [[1]](diffhunk://#diff-e7d4aca53285747b73e777b0cb2b90701472bfa81c22dff64aa40e3cce26ff97L33-R33) [[2]](diffhunk://#diff-a3ef1c8371da0b756b541de99955e87ad4f757b161dd96783f44cdeacfd120e5L18-R18) [[3]](diffhunk://#diff-9517163f484c71960f5a211483f79b1b06406ee8d44d23fb121ba252e0298316L62-R62) [[4]](diffhunk://#diff-9517163f484c71960f5a211483f79b1b06406ee8d44d23fb121ba252e0298316L175-R181) [[5]](diffhunk://#diff-9517163f484c71960f5a211483f79b1b06406ee8d44d23fb121ba252e0298316L192-R192) [[6]](diffhunk://#diff-68317b2fefb94b10dd63d348f4d929fbaf0925096568a7c77a64a1d0df672405L18-R18)

These changes ensure that job comparisons are accurate and less error-prone throughout the codebase.

Fixes #105 too