### PR TITLE
feat(shipment): add manual shipment merge actions

### DIFF
--- a/game/Code/Entity/Entities/ShipmentEntity.cs
+++ b/game/Code/Entity/Entities/ShipmentEntity.cs
@@ -5,7 +5,7 @@ namespace Dxura.RP.Game.Entities;
 
 public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 {
-	private const float DepositRadius = 32f;
+	private const float DepositRadius = 24f;
 
 	[Property]
 	[ReadOnly]

--- a/game/Code/Entity/Entities/ShipmentEntity.cs
+++ b/game/Code/Entity/Entities/ShipmentEntity.cs
@@ -5,6 +5,8 @@ namespace Dxura.RP.Game.Entities;
 
 public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 {
+	private const float DepositRadius = 32f;
+
 	[Property]
 	[ReadOnly]
 	[Sync( SyncFlags.FromHost )]
@@ -16,9 +18,11 @@ public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 	public int Quantity { get; private set; }
 
 	[Property]
+	[Sync( SyncFlags.FromHost )]
 	public Guid EquipmentId { get; set; }
 
 	[Property]
+	[Sync( SyncFlags.FromHost )]
 	public int MaxQuantity { get; set; } = 10;
 
 	[Property] public required GameObject EquipmentPreview { get; set; }
@@ -79,6 +83,11 @@ public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 		}
 
 		var equipment = GameModeEquipments.FindById( EquipmentId );
+		if ( equipment == null )
+		{
+			return;
+		}
+
 		EquipmentRenderer.Model = equipment.GetWorldModel();
 		EquipmentRenderer.WorldScale = 1.1f;
 		TypeText.Text = equipment.DisplayName();
@@ -87,12 +96,129 @@ public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 
 	public void ConfigureHost( GameModeEquipmentDto equipment, int quantity )
 	{
+		ConfigureHost( equipment, quantity, quantity );
+	}
+
+	public void ConfigureHost( GameModeEquipmentDto equipment, int maxQuantity, int quantity )
+	{
 		Assert.True( Networking.IsHost );
 
 		EquipmentId = equipment.GameModeAddonContentId;
-		MaxQuantity = Math.Max( 1, quantity );
-		Quantity = MaxQuantity;
+		MaxQuantity = Math.Max( 1, maxQuantity );
+		Quantity = Math.Clamp( quantity, 1, MaxQuantity );
 		UpdateState();
+	}
+
+	public bool CanDeposit( DroppedEquipment droppedEquipment )
+	{
+		return droppedEquipment.IsValid() &&
+		       Quantity < MaxQuantity &&
+		       droppedEquipment.EquipmentId == EquipmentId;
+	}
+
+	public bool TryDepositHost( DroppedEquipment droppedEquipment )
+	{
+		Assert.True( Networking.IsHost );
+
+		if ( !CanDeposit( droppedEquipment ) )
+		{
+			return false;
+		}
+
+		Quantity++;
+		droppedEquipment.GameObject.Destroy();
+		return true;
+	}
+
+	[Rpc.Host]
+	public void DepositNearbyDropsHost()
+	{
+		var callerId = Rpc.CallerId;
+		if ( Cooldown.Current.CheckAndStartCooldown( $"{callerId}:shipment:deposit", Config.Current.Game.ShipmentUseCooldown ) )
+		{
+			return;
+		}
+
+		var player = GameUtils.GetPlayerByConnectionId( callerId );
+		if ( !player.IsValid() || !HasDepositLineOfSight( player ) )
+		{
+			return;
+		}
+
+		foreach ( var droppedEquipment in FindNearbyDepositDrops() )
+		{
+			if ( !TryDepositHost( droppedEquipment ) )
+			{
+				continue;
+			}
+
+			if ( Quantity >= MaxQuantity )
+			{
+				return;
+			}
+		}
+	}
+
+	public static int CreateFromDropsHost( IReadOnlyList<DroppedEquipment> drops, Player? owner )
+	{
+		Assert.True( Networking.IsHost );
+
+		var validDrops = drops
+			.Where( drop => drop.IsValid() && drop.EquipmentId != Guid.Empty )
+			.ToList();
+
+		if ( validDrops.Count < 2 )
+		{
+			return 0;
+		}
+
+		var equipmentId = validDrops[0].EquipmentId;
+		if ( validDrops.Any( drop => drop.EquipmentId != equipmentId ) )
+		{
+			return 0;
+		}
+
+		var equipment = validDrops[0].Resource ?? GameModeEquipments.FindById( equipmentId );
+		if ( equipment == null )
+		{
+			return 0;
+		}
+
+		var marketItem = GameModeMarketItems.FindShipmentMarketItem( equipment );
+		var maxQuantity = Math.Max( 1, marketItem?.Quantity ?? 10 );
+		var marketItemId = validDrops.Select( drop => drop.MarketItemId ).FirstOrDefault( id => id != Guid.Empty );
+		if ( marketItemId == Guid.Empty && marketItem != null )
+		{
+			marketItemId = marketItem.Id;
+		}
+
+		var createdQuantity = 0;
+		while ( validDrops.Count > 0 )
+		{
+			var quantity = Math.Min( maxQuantity, validDrops.Count );
+			if ( createdQuantity == 0 && quantity < 2 )
+			{
+				break;
+			}
+
+			var shipmentDrops = validDrops.Take( quantity ).ToList();
+			var position = shipmentDrops.Aggregate( Vector3.Zero, ( sum, drop ) => sum + drop.WorldPosition ) / shipmentDrops.Count;
+
+			if ( !TryCreateShipmentHost( equipment, marketItemId, maxQuantity, quantity, position, owner ) )
+			{
+				break;
+			}
+
+			foreach ( var drop in shipmentDrops )
+			{
+				drop.GameObject.Destroy();
+			}
+
+			createdQuantity += shipmentDrops.Count;
+			validDrops.RemoveRange( 0, shipmentDrops.Count );
+		}
+
+		return createdQuantity;
 	}
 
 	public bool Press( IPressable.Event e )
@@ -186,7 +312,79 @@ public class ShipmentEntity : BaseEntity, IWireUsable, Component.IPressable
 
 	private void OnQuantityChange( int oldValue, int newValue )
 	{
-		QuantityText.Text = $"{Quantity}/{MaxQuantity}";
+		if ( QuantityText.IsValid() )
+		{
+			QuantityText.Text = $"{Quantity}/{MaxQuantity}";
+		}
+	}
+
+	private bool HasDepositLineOfSight( Player player )
+	{
+		var tr = Scene.Trace.Ray( player.AimRay, Config.Current.Game.ReachDistance )
+			.IgnoreGameObjectHierarchy( player.GameObject )
+			.WithoutTags( Constants.TraceIgnoreTags )
+			.UseHitboxes()
+			.Run();
+
+		return tr.Hit && tr.GameObject.Root == GameObject.Root;
+	}
+
+	private List<DroppedEquipment> FindNearbyDepositDrops()
+	{
+		if ( Quantity >= MaxQuantity || EquipmentId == Guid.Empty )
+		{
+			return [];
+		}
+
+		var bounds = new BBox(
+			WorldPosition - Vector3.One * DepositRadius,
+			WorldPosition + Vector3.One * DepositRadius );
+
+		return Scene.FindInPhysics( bounds )
+			.Select( gameObject => gameObject.Root.GetComponent<DroppedEquipment>() )
+			.Where( CanDeposit )
+			.GroupBy( drop => drop.GameObject )
+			.Select( group => group.First() )
+			.OrderBy( drop => drop.WorldPosition.DistanceSquared( WorldPosition ) )
+			.Take( MaxQuantity - Quantity )
+			.ToList();
+	}
+
+	private static bool TryCreateShipmentHost( GameModeEquipmentDto equipment, Guid marketItemId, int maxQuantity,
+		int quantity, Vector3 position, Player? owner )
+	{
+		var shipmentPrefab = GameObject.GetPrefab( GameModeMarketItems.ShipmentPrefabPath );
+		if ( !shipmentPrefab.IsValid() )
+		{
+			return false;
+		}
+
+		var shipmentObject = shipmentPrefab.Clone();
+		shipmentObject.WorldPosition = position;
+
+		var shipmentEntity = shipmentObject.GetComponent<ShipmentEntity>();
+		var shipmentBaseEntity = shipmentObject.GetComponent<BaseEntity>();
+		if ( !shipmentEntity.IsValid() || !shipmentBaseEntity.IsValid() )
+		{
+			shipmentObject.Destroy();
+			return false;
+		}
+
+		shipmentEntity.MarketItemId = marketItemId;
+		shipmentEntity.ConfigureHost( equipment, maxQuantity, quantity );
+
+		if ( owner.IsValid() )
+		{
+			GameUtils.AssignSpawnedOwnership( shipmentObject, owner );
+			shipmentObject.NetworkSpawn( owner.Connection );
+		}
+		else
+		{
+			shipmentObject.NetworkSpawn();
+		}
+
+		GameManager.Instance.PurchaseSound?.Broadcast( shipmentObject.WorldPosition, shipmentObject );
+		return true;
 	}
 
 	private void AnimatePreview()

--- a/game/Code/Equipment/DroppedEquipment.cs
+++ b/game/Code/Equipment/DroppedEquipment.cs
@@ -7,6 +7,7 @@ namespace Dxura.RP.Game;
 public class DroppedEquipment : Component, Component.IPressable
 {
 	private const float ShipmentMergeRadius = 96f;
+	private const float ExistingShipmentDepositRadius = 32f;
 	private const int MinShipmentMergeCount = 2;
 
 	[Property]
@@ -232,23 +233,19 @@ public class DroppedEquipment : Component, Component.IPressable
 			return;
 		}
 
-		var createdShipment = false;
+		if ( TryDepositIntoCloseExistingShipmentHost( nearbyRoots, nearbyDrops ) )
+		{
+			return;
+		}
+
 		foreach ( var dropsByEquipment in nearbyDrops.GroupBy( drop => drop.EquipmentId ) )
 		{
 			var drops = dropsByEquipment.ToList();
 			if ( drops.Count >= MinShipmentMergeCount )
 			{
 				ShipmentEntity.CreateFromDropsHost( drops, player );
-				createdShipment = true;
 			}
 		}
-
-		if ( createdShipment )
-		{
-			return;
-		}
-
-		DepositNearbyDropsIntoExistingShipmentsHost( nearbyRoots, nearbyDrops );
 	}
 
 	private List<GameObject> FindNearbyMergeRoots()
@@ -274,28 +271,32 @@ public class DroppedEquipment : Component, Component.IPressable
 			.ToList();
 	}
 
-	private void DepositNearbyDropsIntoExistingShipmentsHost( IEnumerable<GameObject> nearbyRoots,
+	private bool TryDepositIntoCloseExistingShipmentHost( IEnumerable<GameObject> nearbyRoots,
 		IEnumerable<DroppedEquipment> nearbyDrops )
 	{
+		var maxDistanceSquared = ExistingShipmentDepositRadius * ExistingShipmentDepositRadius;
 		var shipment = nearbyRoots
 			.Select( root => root.GetComponent<ShipmentEntity>() )
 			.Where( shipment => shipment.IsValid() )
 			.GroupBy( shipment => shipment.GameObject )
 			.Select( group => group.First() )
-			.Where( shipment => nearbyDrops.Any( shipment.CanDeposit ) )
+			.Where( shipment => shipment.CanDeposit( this ) )
+			.Where( shipment => shipment.WorldPosition.DistanceSquared( WorldPosition ) <= maxDistanceSquared )
 			.OrderBy( shipment => shipment.WorldPosition.DistanceSquared( WorldPosition ) )
 			.FirstOrDefault();
 
 		if ( !shipment.IsValid() )
 		{
-			return;
+			return false;
 		}
 
 		var depositableDrops = nearbyDrops
 			.Where( drop => shipment.CanDeposit( drop ) )
+			.Where( drop => drop.WorldPosition.DistanceSquared( shipment.WorldPosition ) <= maxDistanceSquared )
 			.OrderBy( drop => drop.WorldPosition.DistanceSquared( shipment.WorldPosition ) )
 			.ToList();
 
+		var depositedAny = false;
 		foreach ( var drop in depositableDrops )
 		{
 			if ( !shipment.TryDepositHost( drop ) )
@@ -303,10 +304,14 @@ public class DroppedEquipment : Component, Component.IPressable
 				continue;
 			}
 
+			depositedAny = true;
+
 			if ( shipment.Quantity >= shipment.MaxQuantity )
 			{
 				break;
 			}
 		}
+
+		return depositedAny;
 	}
 }

--- a/game/Code/Equipment/DroppedEquipment.cs
+++ b/game/Code/Equipment/DroppedEquipment.cs
@@ -1,3 +1,4 @@
+using Dxura.RP.Game.Entities;
 using Dxura.RP.Shared;
 using Sandbox.Diagnostics;
 
@@ -5,6 +6,9 @@ namespace Dxura.RP.Game;
 
 public class DroppedEquipment : Component, Component.IPressable
 {
+	private const float ShipmentMergeRadius = 96f;
+	private const int MinShipmentMergeCount = 2;
+
 	[Property]
 	public GameModeEquipmentDto? Resource { get; private set; }
 	
@@ -132,6 +136,24 @@ public class DroppedEquipment : Component, Component.IPressable
 		GameObject.Destroy();
 	}
 
+	[Rpc.Host]
+	public void MergeNearbyIntoShipmentsHost()
+	{
+		var callerId = Rpc.CallerId;
+		if ( Cooldown.Current.CheckAndStartCooldown( $"{callerId}:shipment:merge", Config.Current.Game.ShipmentUseCooldown ) )
+		{
+			return;
+		}
+
+		var player = GameUtils.GetPlayerByConnectionId( callerId );
+		if ( !player.IsValid() || !HasMergeLineOfSight( player ) )
+		{
+			return;
+		}
+
+		MergeNearbyDropsIntoShipmentsHost( player );
+	}
+
 	public static DroppedEquipment CreateHost( GameModeEquipmentDto dto, Vector3 position, Rotation? rotation = null,
 		Equipment? heldWeapon = null, bool networkSpawn = true, Guid marketItemId = default )
 	{
@@ -186,5 +208,55 @@ public class DroppedEquipment : Component, Component.IPressable
 		}
 
 		return droppedWeapon;
+	}
+
+	private bool HasMergeLineOfSight( Player player )
+	{
+		var tr = Scene.Trace.Ray( player.AimRay, Config.Current.Game.ReachDistance )
+			.IgnoreGameObjectHierarchy( player.GameObject )
+			.WithoutTags( Constants.TraceIgnoreTags )
+			.UseHitboxes()
+			.Run();
+
+		return tr.Hit && tr.GameObject.Root == GameObject.Root;
+	}
+
+	private void MergeNearbyDropsIntoShipmentsHost( Player player )
+	{
+		var nearbyRoots = FindNearbyMergeRoots();
+
+		var nearbyDrops = nearbyRoots
+			.Select( root => root.GetComponent<DroppedEquipment>() )
+			.Where( drop => drop.IsValid() && drop.EquipmentId != Guid.Empty )
+			.GroupBy( drop => drop.GameObject )
+			.Select( group => group.First() )
+			.ToList();
+
+		if ( nearbyDrops.Count == 0 )
+		{
+			return;
+		}
+
+		foreach ( var dropsByEquipment in nearbyDrops.GroupBy( drop => drop.EquipmentId ) )
+		{
+			var drops = dropsByEquipment.ToList();
+			if ( drops.Count >= MinShipmentMergeCount )
+			{
+				ShipmentEntity.CreateFromDropsHost( drops, player );
+			}
+		}
+	}
+
+	private List<GameObject> FindNearbyMergeRoots()
+	{
+		var bounds = new BBox(
+			WorldPosition - Vector3.One * ShipmentMergeRadius,
+			WorldPosition + Vector3.One * ShipmentMergeRadius );
+
+		return Scene.FindInPhysics( bounds )
+			.Select( gameObject => gameObject.Root )
+			.Where( root => root.IsValid() )
+			.Distinct()
+			.ToList();
 	}
 }

--- a/game/Code/Equipment/DroppedEquipment.cs
+++ b/game/Code/Equipment/DroppedEquipment.cs
@@ -225,26 +225,30 @@ public class DroppedEquipment : Component, Component.IPressable
 	{
 		var nearbyRoots = FindNearbyMergeRoots();
 
-		var nearbyDrops = nearbyRoots
-			.Select( root => root.GetComponent<DroppedEquipment>() )
-			.Where( drop => drop.IsValid() && drop.EquipmentId != Guid.Empty )
-			.GroupBy( drop => drop.GameObject )
-			.Select( group => group.First() )
-			.ToList();
+		var nearbyDrops = FindNearbyDrops( nearbyRoots );
 
 		if ( nearbyDrops.Count == 0 )
 		{
 			return;
 		}
 
+		var createdShipment = false;
 		foreach ( var dropsByEquipment in nearbyDrops.GroupBy( drop => drop.EquipmentId ) )
 		{
 			var drops = dropsByEquipment.ToList();
 			if ( drops.Count >= MinShipmentMergeCount )
 			{
 				ShipmentEntity.CreateFromDropsHost( drops, player );
+				createdShipment = true;
 			}
 		}
+
+		if ( createdShipment )
+		{
+			return;
+		}
+
+		DepositNearbyDropsIntoExistingShipmentsHost( nearbyRoots, nearbyDrops );
 	}
 
 	private List<GameObject> FindNearbyMergeRoots()
@@ -258,5 +262,51 @@ public class DroppedEquipment : Component, Component.IPressable
 			.Where( root => root.IsValid() )
 			.Distinct()
 			.ToList();
+	}
+
+	private static List<DroppedEquipment> FindNearbyDrops( IEnumerable<GameObject> nearbyRoots )
+	{
+		return nearbyRoots
+			.Select( root => root.GetComponent<DroppedEquipment>() )
+			.Where( drop => drop.IsValid() && drop.EquipmentId != Guid.Empty )
+			.GroupBy( drop => drop.GameObject )
+			.Select( group => group.First() )
+			.ToList();
+	}
+
+	private void DepositNearbyDropsIntoExistingShipmentsHost( IEnumerable<GameObject> nearbyRoots,
+		IEnumerable<DroppedEquipment> nearbyDrops )
+	{
+		var shipment = nearbyRoots
+			.Select( root => root.GetComponent<ShipmentEntity>() )
+			.Where( shipment => shipment.IsValid() )
+			.GroupBy( shipment => shipment.GameObject )
+			.Select( group => group.First() )
+			.Where( shipment => nearbyDrops.Any( shipment.CanDeposit ) )
+			.OrderBy( shipment => shipment.WorldPosition.DistanceSquared( WorldPosition ) )
+			.FirstOrDefault();
+
+		if ( !shipment.IsValid() )
+		{
+			return;
+		}
+
+		var depositableDrops = nearbyDrops
+			.Where( drop => shipment.CanDeposit( drop ) )
+			.OrderBy( drop => drop.WorldPosition.DistanceSquared( shipment.WorldPosition ) )
+			.ToList();
+
+		foreach ( var drop in depositableDrops )
+		{
+			if ( !shipment.TryDepositHost( drop ) )
+			{
+				continue;
+			}
+
+			if ( shipment.Quantity >= shipment.MaxQuantity )
+			{
+				break;
+			}
+		}
 	}
 }

--- a/game/Code/Equipment/Equipments/Default/HandsEquipment.cs
+++ b/game/Code/Equipment/Equipments/Default/HandsEquipment.cs
@@ -1,3 +1,5 @@
+using Dxura.RP.Game.Entities;
+
 namespace Dxura.RP.Game.Equipments;
 
 /// <summary>
@@ -229,6 +231,23 @@ public class HandsEquipment : InputWeaponComponent, IEquipmentEvents, IInputHint
 		}
 
 		var targetGo = trace.Value.GameObject.Root;
+
+		if ( Input.Down( "run" ) && Input.Pressed( "attack2" ) )
+		{
+			var shipmentEntity = targetGo.GetComponent<ShipmentEntity>();
+			if ( shipmentEntity.IsValid() )
+			{
+				shipmentEntity.DepositNearbyDropsHost();
+				return;
+			}
+
+			var droppedEquipment = targetGo.GetComponent<DroppedEquipment>();
+			if ( droppedEquipment.IsValid() )
+			{
+				droppedEquipment.MergeNearbyIntoShipmentsHost();
+				return;
+			}
+		}
 
 		if ( targetGo.Components.Get<IHandEvents>() != null )
 		{

--- a/game/Code/Utilities/Resource/GameModeMarketItems.cs
+++ b/game/Code/Utilities/Resource/GameModeMarketItems.cs
@@ -44,6 +44,27 @@ public static class GameModeMarketItems
 		return GameModeEquipments.FindByDtoId( item.ReferenceId.Value );
 	}
 
+	public static GameModeMarketItemDto? FindShipmentMarketItem( GameModeEquipmentDto? equipment )
+	{
+		if ( equipment == null )
+		{
+			return null;
+		}
+
+		return All.FirstOrDefault( item =>
+		{
+			if ( item.Type != GameModeMarketItemType.Equipment || item.Quantity <= 1 )
+			{
+				return false;
+			}
+
+			var itemEquipment = ResolveEquipment( item );
+			return itemEquipment != null &&
+			       (itemEquipment.Id == equipment.Id ||
+			        itemEquipment.GameModeAddonContentId == equipment.GameModeAddonContentId);
+		} );
+	}
+
 	public static string DisplayName( GameModeMarketItemDto? item )
 	{
 		if ( item == null )


### PR DESCRIPTION
## Summary
- Add Shift + right click shipment actions using hands equipment
- Allow dropped identical equipment to be manually combined into shipment crates
- Allow existing shipment crates to manually pull in nearby matching dropped equipment
- Keep validation host-side to avoid continuous physics listeners/scans

Closes #45