### PR TITLE
feat(menu): Add modular addon entries for the Tab Menu (#55)

### DIFF
--- a/game/Code/UI/Menus/TabMenu/TabMenu.razor
+++ b/game/Code/UI/Menus/TabMenu/TabMenu.razor
@@ -36,129 +36,34 @@
 			</div>
 			
 			<div class="navigation pb-4 flex flex-col gap-1 flex-grow overflow-y-auto">
-				@if ( Config.Current.Game.ShowDashboardMenu )
+				@foreach ( var section in MainSections )
 				{
 					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Dashboard ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Dashboard ))">
-						<i class="material-icons mr-3">dashboard</i> <span>#tabmenu.dashboard</span>
+						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( IsActiveEntry( section ) ? "active-btn" : "" )"
+						@onclick="@(() => HandleMenuEntry( section.Id ))">
+						<i class="material-icons mr-3">@section.Icon</i> <span>@GetEntryLabel( section )</span>
 					</button>
 				}
-				
-				@if ( Config.Current.Game.RulesEnabled )
-				{
-					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Rules ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Rules ))">
-						<i class="material-icons mr-3">rule</i> <span>#tabmenu.rules</span>
-					</button>
-				}
-				
-				<button
-					class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Players ? "active-btn" : "" )"
-					@onclick="@(() => SetSelectedSection( MenuSection.Players ))">
-					<i class="material-icons mr-3">group</i> <span>#tabmenu.players</span>
-				</button>
-
-				@if ( IsSectionAvailableInCurrentState( MenuSection.Jobs ) && Config.Current.Game.ShowJobsMenu )
-				{
-					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Jobs ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Jobs ))">
-						<i class="material-icons mr-3">work</i> <span>#tabmenu.jobs</span>
-					</button>
-				}
-
-				@if ( IsSectionAvailableInCurrentState( MenuSection.Market ) && Config.Current.Game.ShowMarketMenu )
-				{
-					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Market ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Market ))">
-						<i class="material-icons mr-3">store</i> <span>#tabmenu.market</span>
-					</button>
-				}
-
-				@if ( IsSectionAvailableInCurrentState( MenuSection.Governance ) && Player.Local?.Job.IsGovernmentRole() == true )
-				{
-					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Governance ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Governance ))">
-						<i class="material-icons mr-3">gavel</i> <span>#tabmenu.governance</span>
-					</button>
-				}
-				
-				@if ( IsSectionAvailableInCurrentState( MenuSection.Faction ) && Config.Current.Game.FactionsEnabled )
-				{
-					<button
-						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Faction ? "active-btn" : "" )"
-						@onclick="@(() => SetSelectedSection( MenuSection.Faction ))">
-						<i class="material-icons mr-3">account_tree</i> <span>#tabmenu.faction</span>
-					</button>
-				}
-
 			</div>
 
 			<div class="p-4 flex flex-col gap-1">
-				<button class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary"
-				        @onclick="@(() => DiscordWebPanel.Open( Panel, Config.Current.Game.DiscordUrl ))">
-					<i class="material-icons mr-3">discord</i> <span>#tabmenu.discord</span>
-				</button>
-				
-				<button class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary"
-				        @onclick="@(() =>
-				                  {
-					                  Clipboard.SetText( "https://opencollective.com/dxrp" );
-					                  _supportText = "#generic.copied";
-				                  })">
-					<i class="material-icons mr-3">handshake</i> @_supportText
-				</button>
-				
-				<button
-					class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Credits ? "active" : "" )"
-					@onclick="@(() => SetSelectedSection( MenuSection.Credits ))">
-					<i class="material-icons mr-3">copyright</i> <span>#tabmenu.credits</span>
-				</button>
-
-				@* <button *@
-				@* 	class="menuButton flex items-center text-lg rounded-lg p-3 cursor-pointer text-tertiary @( SelectedSection == MenuSection.Admin ? "active" : "" )" *@
-				@* 	@onclick="@(() => SetSelectedSection( MenuSection.Admin ))"> *@
-				@* 	<i class="material-icons mr-3">admin_panel_settings</i> <span>#tabmenu.admin</span> *@
-				@* </button> *@
+				@foreach ( var section in FooterSections )
+				{
+					<button
+						class="menuButton flex items-center text-lg p-3 cursor-pointer text-tertiary @( IsActiveEntry( section ) ? "active-btn" : "" )"
+						@onclick="@(() => HandleMenuEntry( section.Id ))">
+						<i class="material-icons mr-3">@section.Icon</i> <span>@GetEntryLabel( section )</span>
+					</button>
+				}
 			</div>
 		</div>
 
 		<div class="content-panel flex flex-col min-h-0">
 			<div class="section-body flex-grow min-h-0 overflow-y-auto">
 				<div class="section-content">
-					@switch ( SelectedSection )
+					@if ( SelectedSection != null )
 					{
-						case MenuSection.Dashboard:
-							<DashboardTabMenuSection/>
-							break;
-						case MenuSection.Rules:
-							<RulesTabMenuSection/>
-							break;
-						case MenuSection.Players:
-							<PlayersTabMenuSection @key="_playersSectionRevision" />
-							break;
-						case MenuSection.Jobs:
-							<JobTabMenuSection/>
-							break;
-						case MenuSection.Market:
-							<MarketTabMenuSection/>
-							break;
-						case MenuSection.Governance:
-							<GovernanceTabMenuSection/>
-							break;
-						case MenuSection.Faction:
-							<FactionTabMenuSection/>
-							break;
-						case MenuSection.Credits:
-							<CreditsTabMenuSection/>
-							break;
-						case MenuSection.Admin:
-							<AdminTabMenuSection/>
-							break;
+						<TabMenuSectionHost @key="SelectedSectionHostKey" Section="@SelectedSection" Revision="@_selectedSectionRevision" />
 					}
 				</div>
 			</div>
@@ -170,31 +75,28 @@
 @code
 {
 	public static bool IsOpen { get; private set; }
-	
-	enum MenuSection
-	{
-		Dashboard,
-		Rules,
-		Players,
-		Jobs,
-		Market,
-		Governance,
-		Faction,
-		Credits,
-		Admin
-	}
 
-	// Sections that should be hidden/blocked when player is dead
-	private readonly MenuSection[] _restrictedWhenDeadSections = { MenuSection.Jobs, MenuSection.Market, MenuSection.Governance };
-	private readonly MenuSection[] _restrictedWhenRestrictedSections = { MenuSection.Jobs, MenuSection.Market, MenuSection.Governance };
-
-	private MenuSection SelectedSection { get; set; } = MenuSection.Dashboard;
+	private string SelectedSectionId { get; set; } = "dashboard";
 	private bool IsActive { get; set; }
 
-	private string _supportText = "#generic.support.project";
-	private int _playersSectionRevision;
+	private readonly Dictionary<string, string> _entryLabelOverrides = new( StringComparer.OrdinalIgnoreCase );
+	private int _selectedSectionRevision;
 	
 	private static TabMenu? _instance;
+
+	private IReadOnlyList<TabMenuSectionDefinition> AvailableSections =>
+		TabMenuSectionRegistry.Sections
+			.Where( section => section.IsAvailable( IsPlayerDead(), IsPlayerRestricted() ) )
+			.ToArray();
+
+	private IEnumerable<TabMenuSectionDefinition> MainSections => AvailableSections.Where( section => !section.Footer );
+	private IEnumerable<TabMenuSectionDefinition> FooterSections => AvailableSections.Where( section => section.Footer );
+
+	private TabMenuSectionDefinition? SelectedSection =>
+		AvailableSections.FirstOrDefault( section => section.IsTab && section.Id == SelectedSectionId )
+		?? GetDefaultSection();
+
+	private string SelectedSectionHostKey => $"{SelectedSection?.Id}:{_selectedSectionRevision}";
 
 	private bool IsPlayerDead()
 	{
@@ -206,31 +108,20 @@
 		return Player.Local.IsValid() && Player.Local.Restricted;
 	}
 
-	private bool IsSectionAvailableInCurrentState( MenuSection section )
+	private TabMenuSectionDefinition? GetDefaultSection()
 	{
-		if ( IsPlayerDead() && _restrictedWhenDeadSections.Contains( section ) )
-			return false;
-
-		if ( IsPlayerRestricted() && _restrictedWhenRestrictedSections.Contains( section ) )
-			return false;
-
-		return true;
+		return AvailableSections.FirstOrDefault( section => section.Id == "dashboard" )
+		       ?? AvailableSections.FirstOrDefault( section => section.Id == "players" )
+		       ?? AvailableSections.FirstOrDefault( section => section.IsTab );
 	}
 
 	protected override void OnStart()
 	{
 		_instance = this;
 		IsOpen = false;
+		TabMenuSectionRegistry.Reload();
 		
-		if ( !Config.Current.Game.ShowDashboardMenu )
-		{
-			SelectedSection = MenuSection.Players;
-		}
-		
-		if( !IsSectionAvailableInCurrentState( SelectedSection ) )
-		{
-			SelectedSection = MenuSection.Players;
-		}
+		EnsureSelectedSectionAvailable();
 	}
 
 	protected override void OnUpdate()
@@ -245,33 +136,95 @@
 			{
 				IsActive = true;
 				IsOpen = true;
-				_supportText = "#generic.support.project";
+				_entryLabelOverrides.Clear();
+				TabMenuSectionRegistry.Reload();
+				EnsureSelectedSectionAvailable();
 				StateHasChanged();
 			}
 		}
 
-		if ( IsActive && IsPlayerDead() && !IsSectionAvailableInCurrentState( SelectedSection ) )
+		if ( IsActive && SelectedSection?.Id != SelectedSectionId )
 		{
-			SelectedSection = Config.Current.Game.ShowDashboardMenu ? MenuSection.Dashboard : MenuSection.Players;
+			EnsureSelectedSectionAvailable();
 			StateHasChanged();
 		}
 	}
 
-	private void SetSelectedSection( MenuSection section )
+	private void EnsureSelectedSectionAvailable()
 	{
-		if ( IsPlayerDead() && !IsSectionAvailableInCurrentState( section ) )
+		if ( AvailableSections.Any( section => section.IsTab && section.Id == SelectedSectionId ) )
+		{
+			return;
+		}
+
+		SelectedSectionId = GetDefaultSection()?.Id ?? "players";
+		_selectedSectionRevision++;
+	}
+
+	private bool IsActiveEntry( TabMenuSectionDefinition section )
+	{
+		return section.IsTab && SelectedSectionId == section.Id;
+	}
+
+	private string GetEntryLabel( TabMenuSectionDefinition section )
+	{
+		return _entryLabelOverrides.TryGetValue( section.Id, out var label ) ? label : section.Label;
+	}
+
+	private void HandleMenuEntry( string sectionId )
+	{
+		var section = AvailableSections.FirstOrDefault( section => section.Id == sectionId );
+		if ( section == null )
 		{
 			return;
 		}
 
 		BlurFocusedTextEntries();
 		Sound.Play( "pop" );
-		if ( section == MenuSection.Players )
+
+		if ( section.IsTab )
 		{
-			_playersSectionRevision++;
+			if ( SelectedSectionId == sectionId || sectionId == "players" )
+			{
+				_selectedSectionRevision++;
+			}
+
+			SelectedSectionId = sectionId;
+			StateHasChanged();
+			return;
 		}
 
-		SelectedSection = section;
+		try
+		{
+			if ( section.CopyText != null )
+			{
+				Clipboard.SetText( section.CopyText() );
+				_entryLabelOverrides[section.Id] = section.CopiedLabel;
+			}
+
+			section.OnClick?.Invoke( new TabMenuButtonContext
+			{
+				Panel = Panel,
+				CloseMenu = CloseMenu
+			} );
+		}
+		catch ( Exception ex )
+		{
+			Log.Warning( $"Failed to run tab menu entry '{section.Id}': {ex.Message}" );
+		}
+
+		StateHasChanged();
+	}
+
+	private void SetSelectedSection( string sectionId )
+	{
+		var section = AvailableSections.FirstOrDefault( section => section.IsTab && section.Id == sectionId );
+		if ( section == null )
+		{
+			return;
+		}
+
+		SelectedSectionId = sectionId;
 		StateHasChanged();
 	}
 	
@@ -283,7 +236,8 @@
 		}
 
 		PlayersTabMenuSection.PendingFocusSteamId = steamId;
-		_instance.SelectedSection = MenuSection.Players;
+		_instance.SelectedSectionId = "players";
+		_instance._selectedSectionRevision++;
 		_instance.IsActive = true;
 		IsOpen = true;
 		_instance.StateHasChanged();
@@ -321,6 +275,8 @@
 
 	protected override int BuildHash()
 	{
-		return HashCode.Combine( SelectedSection, GameManager.Instance.SalaryMultiplier );
+		var visibleSectionIds = string.Join( '|', AvailableSections.Select( section => section.Id ) );
+		var entryLabels = string.Join( '|', _entryLabelOverrides.Select( entry => $"{entry.Key}:{entry.Value}" ) );
+		return HashCode.Combine( SelectedSectionId, _selectedSectionRevision, visibleSectionIds, entryLabels, GameManager.Instance.SalaryMultiplier );
 	}
 }

--- a/game/Code/UI/Menus/TabMenu/TabMenu.razor
+++ b/game/Code/UI/Menus/TabMenu/TabMenu.razor
@@ -80,20 +80,16 @@
 	private bool IsActive { get; set; }
 
 	private readonly Dictionary<string, string> _entryLabelOverrides = new( StringComparer.OrdinalIgnoreCase );
+	private IReadOnlyList<TabMenuSectionDefinition> _availableSections = [];
 	private int _selectedSectionRevision;
 	
 	private static TabMenu? _instance;
 
-	private IReadOnlyList<TabMenuSectionDefinition> AvailableSections =>
-		TabMenuSectionRegistry.Sections
-			.Where( section => section.IsAvailable( IsPlayerDead(), IsPlayerRestricted() ) )
-			.ToArray();
-
-	private IEnumerable<TabMenuSectionDefinition> MainSections => AvailableSections.Where( section => !section.Footer );
-	private IEnumerable<TabMenuSectionDefinition> FooterSections => AvailableSections.Where( section => section.Footer );
+	private IEnumerable<TabMenuSectionDefinition> MainSections => _availableSections.Where( section => !section.Footer );
+	private IEnumerable<TabMenuSectionDefinition> FooterSections => _availableSections.Where( section => section.Footer );
 
 	private TabMenuSectionDefinition? SelectedSection =>
-		AvailableSections.FirstOrDefault( section => section.IsTab && section.Id == SelectedSectionId )
+		_availableSections.FirstOrDefault( section => section.IsTab && section.Id == SelectedSectionId )
 		?? GetDefaultSection();
 
 	private string SelectedSectionHostKey => $"{SelectedSection?.Id}:{_selectedSectionRevision}";
@@ -110,9 +106,9 @@
 
 	private TabMenuSectionDefinition? GetDefaultSection()
 	{
-		return AvailableSections.FirstOrDefault( section => section.Id == "dashboard" )
-		       ?? AvailableSections.FirstOrDefault( section => section.Id == "players" )
-		       ?? AvailableSections.FirstOrDefault( section => section.IsTab );
+		return _availableSections.FirstOrDefault( section => section.Id == "dashboard" )
+		       ?? _availableSections.FirstOrDefault( section => section.Id == "players" )
+		       ?? _availableSections.FirstOrDefault( section => section.IsTab );
 	}
 
 	protected override void OnStart()
@@ -120,12 +116,18 @@
 		_instance = this;
 		IsOpen = false;
 		TabMenuSectionRegistry.Reload();
+		RefreshAvailableSections();
 		
 		EnsureSelectedSectionAvailable();
 	}
 
 	protected override void OnUpdate()
 	{
+		if ( IsActive )
+		{
+			RefreshAvailableSections();
+		}
+
 		if ( Input.Pressed( "TabMenu" ) || (IsActive && PauseMenu.IsOpen) )
 		{
 			if ( IsActive )
@@ -138,6 +140,7 @@
 				IsOpen = true;
 				_entryLabelOverrides.Clear();
 				TabMenuSectionRegistry.Reload();
+				RefreshAvailableSections();
 				EnsureSelectedSectionAvailable();
 				StateHasChanged();
 			}
@@ -150,9 +153,19 @@
 		}
 	}
 
+	private void RefreshAvailableSections()
+	{
+		var isPlayerDead = IsPlayerDead();
+		var isPlayerRestricted = IsPlayerRestricted();
+
+		_availableSections = TabMenuSectionRegistry.Sections
+			.Where( section => section.IsAvailable( isPlayerDead, isPlayerRestricted ) )
+			.ToArray();
+	}
+
 	private void EnsureSelectedSectionAvailable()
 	{
-		if ( AvailableSections.Any( section => section.IsTab && section.Id == SelectedSectionId ) )
+		if ( _availableSections.Any( section => section.IsTab && section.Id == SelectedSectionId ) )
 		{
 			return;
 		}
@@ -173,7 +186,7 @@
 
 	private void HandleMenuEntry( string sectionId )
 	{
-		var section = AvailableSections.FirstOrDefault( section => section.Id == sectionId );
+		var section = _availableSections.FirstOrDefault( section => section.Id == sectionId );
 		if ( section == null )
 		{
 			return;
@@ -213,18 +226,6 @@
 			Log.Warning( $"Failed to run tab menu entry '{section.Id}': {ex.Message}" );
 		}
 
-		StateHasChanged();
-	}
-
-	private void SetSelectedSection( string sectionId )
-	{
-		var section = AvailableSections.FirstOrDefault( section => section.IsTab && section.Id == sectionId );
-		if ( section == null )
-		{
-			return;
-		}
-
-		SelectedSectionId = sectionId;
 		StateHasChanged();
 	}
 	
@@ -275,7 +276,7 @@
 
 	protected override int BuildHash()
 	{
-		var visibleSectionIds = string.Join( '|', AvailableSections.Select( section => section.Id ) );
+		var visibleSectionIds = string.Join( '|', _availableSections.Select( section => section.Id ) );
 		var entryLabels = string.Join( '|', _entryLabelOverrides.Select( entry => $"{entry.Key}:{entry.Value}" ) );
 		return HashCode.Combine( SelectedSectionId, _selectedSectionRevision, visibleSectionIds, entryLabels, GameManager.Instance.SalaryMultiplier );
 	}

--- a/game/Code/UI/Menus/TabMenu/TabMenuSectionHost.cs
+++ b/game/Code/UI/Menus/TabMenu/TabMenuSectionHost.cs
@@ -1,0 +1,56 @@
+namespace Dxura.RP.Game.UI;
+
+public sealed class TabMenuSectionHost : Panel
+{
+	public TabMenuSectionDefinition? Section { get; set; }
+	public int Revision { get; set; }
+
+	private string? _mountedSectionId;
+	private int _mountedRevision = -1;
+
+	protected override void OnParametersSet()
+	{
+		base.OnParametersSet();
+		MountSection();
+	}
+
+	private void MountSection()
+	{
+		if ( Section == null )
+		{
+			DeleteChildren( true );
+			_mountedSectionId = null;
+			_mountedRevision = -1;
+			return;
+		}
+
+		if ( Section.PanelType == null )
+		{
+			DeleteChildren( true );
+			_mountedSectionId = null;
+			_mountedRevision = -1;
+			return;
+		}
+
+		if ( _mountedSectionId == Section.Id && _mountedRevision == Revision )
+		{
+			return;
+		}
+
+		DeleteChildren( true );
+
+		var type = TypeLibrary.GetType( Section.PanelType );
+		var panel = type?.Create<Panel>();
+		if ( !panel.IsValid() )
+		{
+			Log.Warning( $"Failed to create tab menu section '{Section.Id}' ({Section.PanelType.Name})." );
+			_mountedSectionId = null;
+			_mountedRevision = -1;
+			return;
+		}
+
+		panel.Parent = this;
+		_mountedSectionId = Section.Id;
+		_mountedRevision = Revision;
+	}
+}

--- a/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
+++ b/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
@@ -210,26 +210,6 @@ public sealed class TabMenuSectionRegistry
 			Order = 1000,
 			Placement = TabMenuEntryPlacement.Bottom
 		} );
-
-		Register( new TabMenuSectionDefinition
-		{
-			Id = "discord",
-			Label = "#tabmenu.discord",
-			Icon = "discord",
-			Order = 10,
-			Placement = TabMenuEntryPlacement.Bottom,
-			OnClick = context => DiscordWebPanel.Open( context.Panel, Config.Current.Game.DiscordUrl )
-		} );
-
-		Register( new TabMenuSectionDefinition
-		{
-			Id = "support",
-			Label = "#generic.support.project",
-			Icon = "handshake",
-			Order = 20,
-			Placement = TabMenuEntryPlacement.Bottom,
-			CopyText = () => "https://opencollective.com/dxrp"
-		} );
 	}
 
 	private void RegisterAddonSections()

--- a/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
+++ b/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
@@ -111,6 +111,24 @@ public sealed class TabMenuSectionRegistry
 		_registeredSections.Add( section );
 	}
 
+	public bool Remove( string id )
+	{
+		if ( string.IsNullOrWhiteSpace( id ) )
+		{
+			return false;
+		}
+
+		var section = _registeredSections.FirstOrDefault( section => string.Equals( section.Id, id, StringComparison.OrdinalIgnoreCase ) );
+		if ( section == null )
+		{
+			return false;
+		}
+
+		_registeredSections.Remove( section );
+		_registeredIds.Remove( section.Id );
+		return true;
+	}
+
 	private static IReadOnlyList<TabMenuSectionDefinition> BuildSections()
 	{
 		var registry = new TabMenuSectionRegistry();

--- a/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
+++ b/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
@@ -1,0 +1,256 @@
+namespace Dxura.RP.Game.UI;
+
+public enum TabMenuEntryPlacement
+{
+	Top,
+	Bottom
+}
+
+public sealed class TabMenuButtonContext
+{
+	public required Panel Panel { get; init; }
+	public required Action CloseMenu { get; init; }
+}
+
+public sealed class TabMenuSectionDefinition
+{
+	public required string Id { get; init; }
+	public required string Label { get; init; }
+	public required string Icon { get; init; }
+	public Type? PanelType { get; init; }
+	public Func<string>? CopyText { get; init; }
+	public string CopiedLabel { get; init; } = "#generic.copied";
+	public Action<TabMenuButtonContext>? OnClick { get; init; }
+	public int Order { get; init; }
+	public TabMenuEntryPlacement Placement { get; init; }
+	public bool DisabledWhenDead { get; init; }
+	public bool DisabledWhenRestricted { get; init; }
+	public Func<bool>? CanShow { get; init; }
+
+	public bool IsTab => PanelType != null;
+	public bool IsButton => !IsTab && (CopyText != null || OnClick != null);
+	public bool Footer => Placement == TabMenuEntryPlacement.Bottom;
+
+	public bool IsVisible
+	{
+		get
+		{
+			try
+			{
+				return CanShow?.Invoke() ?? true;
+			}
+			catch ( Exception ex )
+			{
+				Log.Warning( $"Failed to evaluate visibility for tab menu section '{Id}': {ex.Message}" );
+				return false;
+			}
+		}
+	}
+
+	public bool IsAvailable( bool isPlayerDead, bool isPlayerRestricted )
+	{
+		if ( isPlayerDead && DisabledWhenDead )
+		{
+			return false;
+		}
+
+		if ( isPlayerRestricted && DisabledWhenRestricted )
+		{
+			return false;
+		}
+
+		return IsVisible;
+	}
+}
+
+public interface ITabMenuSectionProvider
+{
+	void RegisterTabMenuSections( TabMenuSectionRegistry registry );
+}
+
+public sealed class TabMenuSectionRegistry
+{
+	private static IReadOnlyList<TabMenuSectionDefinition>? _sections;
+
+	private readonly List<TabMenuSectionDefinition> _registeredSections = [];
+	private readonly HashSet<string> _registeredIds = new( StringComparer.OrdinalIgnoreCase );
+
+	public static IReadOnlyList<TabMenuSectionDefinition> Sections => _sections ??= BuildSections();
+
+	public static void Reload()
+	{
+		_sections = null;
+	}
+
+	public void Register( TabMenuSectionDefinition section )
+	{
+		if ( string.IsNullOrWhiteSpace( section.Id ) )
+		{
+			Log.Warning( "Ignoring tab menu section with no id." );
+			return;
+		}
+
+		if ( section.PanelType != null && !typeof( Panel ).IsAssignableFrom( section.PanelType ) )
+		{
+			Log.Warning( $"Ignoring tab menu section '{section.Id}' because its panel type is invalid." );
+			return;
+		}
+
+		if ( !section.IsTab && !section.IsButton )
+		{
+			Log.Warning( $"Ignoring tab menu entry '{section.Id}' because it has no panel or action." );
+			return;
+		}
+
+		if ( !_registeredIds.Add( section.Id ) )
+		{
+			Log.Warning( $"Ignoring duplicate tab menu section id '{section.Id}'." );
+			return;
+		}
+
+		_registeredSections.Add( section );
+	}
+
+	private static IReadOnlyList<TabMenuSectionDefinition> BuildSections()
+	{
+		var registry = new TabMenuSectionRegistry();
+		registry.RegisterNativeSections();
+		registry.RegisterAddonSections();
+
+		return registry._registeredSections
+			.OrderBy( section => section.Footer )
+			.ThenBy( section => section.Order )
+			.ThenBy( section => section.Label )
+			.ToArray();
+	}
+
+	private void RegisterNativeSections()
+	{
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "dashboard",
+			Label = "#tabmenu.dashboard",
+			Icon = "dashboard",
+			PanelType = typeof( DashboardTabMenuSection ),
+			Order = 0,
+			CanShow = () => Config.Current.Game.ShowDashboardMenu
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "rules",
+			Label = "#tabmenu.rules",
+			Icon = "rule",
+			PanelType = typeof( RulesTabMenuSection ),
+			Order = 10,
+			CanShow = () => Config.Current.Game.RulesEnabled
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "players",
+			Label = "#tabmenu.players",
+			Icon = "group",
+			PanelType = typeof( PlayersTabMenuSection ),
+			Order = 20
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "jobs",
+			Label = "#tabmenu.jobs",
+			Icon = "work",
+			PanelType = typeof( JobTabMenuSection ),
+			Order = 30,
+			DisabledWhenDead = true,
+			DisabledWhenRestricted = true,
+			CanShow = () => Config.Current.Game.ShowJobsMenu
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "market",
+			Label = "#tabmenu.market",
+			Icon = "store",
+			PanelType = typeof( MarketTabMenuSection ),
+			Order = 40,
+			DisabledWhenDead = true,
+			DisabledWhenRestricted = true,
+			CanShow = () => Config.Current.Game.ShowMarketMenu
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "governance",
+			Label = "#tabmenu.governance",
+			Icon = "gavel",
+			PanelType = typeof( GovernanceTabMenuSection ),
+			Order = 50,
+			DisabledWhenDead = true,
+			DisabledWhenRestricted = true,
+			CanShow = () => Player.Local?.Job.IsGovernmentRole() == true
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "faction",
+			Label = "#tabmenu.faction",
+			Icon = "account_tree",
+			PanelType = typeof( FactionTabMenuSection ),
+			Order = 60,
+			CanShow = () => Config.Current.Game.FactionsEnabled
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "credits",
+			Label = "#tabmenu.credits",
+			Icon = "copyright",
+			PanelType = typeof( CreditsTabMenuSection ),
+			Order = 1000,
+			Placement = TabMenuEntryPlacement.Bottom
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "discord",
+			Label = "#tabmenu.discord",
+			Icon = "discord",
+			Order = 10,
+			Placement = TabMenuEntryPlacement.Bottom,
+			OnClick = context => DiscordWebPanel.Open( context.Panel, Config.Current.Game.DiscordUrl )
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "support",
+			Label = "#generic.support.project",
+			Icon = "handshake",
+			Order = 20,
+			Placement = TabMenuEntryPlacement.Bottom,
+			CopyText = () => "https://opencollective.com/dxrp"
+		} );
+	}
+
+	private void RegisterAddonSections()
+	{
+		var providerTypes = TypeLibrary.GetTypes<ITabMenuSectionProvider>();
+
+		foreach ( var type in providerTypes.Where( t => !t.IsAbstract && t.TargetType != null ) )
+		{
+			try
+			{
+				if ( TypeLibrary.Create<ITabMenuSectionProvider>( type.TargetType ) is not { } provider )
+				{
+					continue;
+				}
+
+				provider.RegisterTabMenuSections( this );
+			}
+			catch ( Exception ex )
+			{
+				Log.Warning( $"Failed to register tab menu sections from {type.Name}: {ex.Message}" );
+			}
+		}
+	}
+}

--- a/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
+++ b/game/Code/UI/Menus/TabMenu/TabMenuSectionRegistry.cs
@@ -228,6 +228,26 @@ public sealed class TabMenuSectionRegistry
 			Order = 1000,
 			Placement = TabMenuEntryPlacement.Bottom
 		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "discord",
+			Label = "#tabmenu.discord",
+			Icon = "discord",
+			Order = 10,
+			Placement = TabMenuEntryPlacement.Bottom,
+			OnClick = context => DiscordWebPanel.Open( context.Panel, Config.Current.Game.DiscordUrl )
+		} );
+
+		Register( new TabMenuSectionDefinition
+		{
+			Id = "support",
+			Label = "#generic.support.project",
+			Icon = "handshake",
+			Order = 20,
+			Placement = TabMenuEntryPlacement.Bottom,
+			CopyText = () => "https://opencollective.com/dxrp"
+		} );
 	}
 
 	private void RegisterAddonSections()


### PR DESCRIPTION
## PR Title

Add modular addon entries for the Tab Menu

## Summary

Adds a modular Tab Menu registration system so addons can extend the Tab Menu without editing `TabMenu.razor`.

The Tab Menu now supports two kinds of addon entries:

- **Tabs**: entries that open a custom Razor panel.
- **Buttons**: entries that run an action, such as copying text or opening an external panel.

Both tabs and buttons can be placed either in the main/top navigation area or in the bottom/footer area.

## Example: Registering a Tab

```csharp
using Dxura.RP.Game.UI;

namespace Dxura.RP.Game.Addons.Example;

public sealed class ExampleTabMenuAddon : ITabMenuSectionProvider
{
	public void RegisterTabMenuSections( TabMenuSectionRegistry registry )
	{
		registry.Register( new TabMenuSectionDefinition
		{
			Id = "addons",
			Label = "Addons",
			Icon = "extension",
			PanelType = typeof( AddonsExampleTabMenuSection ),
			Order = 30,
			Placement = TabMenuEntryPlacement.Bottom
		} );
	}
}
```

This registers a real Tab Menu section named `Addons`, shown in the bottom area of the sidebar. When clicked, it displays the `AddonsExampleTabMenuSection` Razor panel.

## Example: Tab UI Panel

```razor
@namespace Dxura.RP.Game.Addons.Example
@inherits Panel

<root>
	<div class="flex flex-col gap-4 bg-secondary-35 rounded-lg p-4 w-full">
		<div class="flex items-center gap-3">
			<i class="material-icons text-accent text-4xl">extension</i>
			<div class="flex flex-col">
				<h1 class="text-2xl text-tertiary text-bold">Addons</h1>
				<span class="text-gray-400">This tab is registered by an addon provider.</span>
			</div>
		</div>

		<div class="flex flex-col gap-2 text-tertiary">
			<p>Provider: <span class="text-accent">ExampleTabMenuAddon</span></p>
			<p>Panel: <span class="text-accent">AddonsExampleTabMenuSection</span></p>
			<p>Path: <span class="text-accent">game/Code/Addons/Example/TabMenu</span></p>
		</div>
	</div>
</root>
```

This is the Razor panel rendered by the tab registered through `PanelType`.

## Example: Registering a Button

```csharp
registry.Register( new TabMenuSectionDefinition
{
	Id = "copy-location",
	Label = "Copy Location",
	Icon = "place",
	Order = 70,
	Placement = TabMenuEntryPlacement.Top,
	CopyText = () => Player.Local.IsValid()
		? Player.Local.WorldPosition.ToString()
		: "Unknown location"
} );
```

This registers a button in the top navigation area. When clicked, it copies the local player's current world position to the clipboard.

## Example: Registering a Custom Action Button

```csharp
registry.Register( new TabMenuSectionDefinition
{
	Id = "open-discord",
	Label = "Discord",
	Icon = "discord",
	Order = 10,
	Placement = TabMenuEntryPlacement.Bottom,
	OnClick = context =>
	{
		DiscordWebPanel.Open( context.Panel, Config.Current.Game.DiscordUrl );
	}
} );
```

This registers a bottom button that runs a custom action when clicked.

<img width="1727" height="781" alt="image" src="https://github.com/user-attachments/assets/580a7238-cd17-4cb5-8516-060a4eef7052" />

Closes #55 
