### PR TITLE
fix(afk): prevent antiafk machine

### DIFF
--- a/game/Code/Config/GameConfig.Player.cs
+++ b/game/Code/Config/GameConfig.Player.cs
@@ -31,7 +31,6 @@ public abstract partial class GameConfig
 	public virtual float AfkCheckInterval { get; set; } = 2.5f;
 	public virtual float TimeUntilAfk { get; set; } = 300f; // 5 minutes
 	public virtual float TimeUntilAfkDemote { get; set; } = 3600f; // 60 minutes
-	public virtual float AfkMovementThreshold { get; set; } = 0.5f; // Minimum movement to not be AFK
 
 	// Armor
 	public virtual float MaxArmor { get; set; } = 100f;

--- a/game/Code/Player/Player.Afk.cs
+++ b/game/Code/Player/Player.Afk.cs
@@ -2,13 +2,70 @@ namespace Dxura.RP.Game;
 
 public partial class Player
 {
+	private const float AfkInputReportInterval = 1f;
+	private const float AfkLookInputThreshold = 0.01f;
+
+	private static readonly string[] AfkActivityActions =
+	[
+		"Forward",
+		"Backward",
+		"Left",
+		"Right",
+		"Jump",
+	];
+
+	private TimeSince _timeSinceLastAfkInputReport = AfkInputReportInterval;
+	private int _localAfkInputActivitySequence;
+
 	/// <summary>
 	///     When the player became AFK. Synced from host; null when not AFK.
 	/// </summary>
 	[Sync( SyncFlags.FromHost )]
 	public TimeSince? AfkSince { get; set; }
 
+	public int AfkInputActivitySequence { get; private set; }
+
 	public float AfkDuration => AfkSince?.Relative ?? 0f;
 
 	public string GetAfkDurationText() => TimeUtils.Format( AfkDuration, TimeDisplayFormat.Duration );
+
+	private void OnUpdateAfkOwner()
+	{
+		if ( !HasAfkInputActivity() || _timeSinceLastAfkInputReport < AfkInputReportInterval )
+		{
+			return;
+		}
+
+		_timeSinceLastAfkInputReport = 0f;
+
+		unchecked
+		{
+			_localAfkInputActivitySequence++;
+		}
+
+		ReportAfkInputActivityHost( _localAfkInputActivitySequence );
+	}
+
+	private static bool HasAfkInputActivity()
+	{
+		if ( MathF.Abs( Input.AnalogLook.pitch ) > AfkLookInputThreshold ||
+		     MathF.Abs( Input.AnalogLook.yaw ) > AfkLookInputThreshold ||
+		     Input.MouseWheel.y != 0f )
+		{
+			return true;
+		}
+
+		return AfkActivityActions.Any( action => Input.Down( action ) );
+	}
+
+	[Rpc.Host]
+	private void ReportAfkInputActivityHost( int activitySequence )
+	{
+		if ( Rpc.Caller != Network.Owner )
+		{
+			return;
+		}
+
+		AfkInputActivitySequence = activitySequence;
+	}
 }

--- a/game/Code/Player/Player.cs
+++ b/game/Code/Player/Player.cs
@@ -46,6 +46,7 @@ public sealed partial class Player : Component, IEquipmentEvents, IDamageEvents,
 			return;
 		}
 
+		OnUpdateAfkOwner();
 		OnUpdateEquipment();
 		OnUpdateCamera();
 		OnUpdatePresence();

--- a/game/Code/System/RP/AfkSystem.cs
+++ b/game/Code/System/RP/AfkSystem.cs
@@ -5,7 +5,7 @@ public class AfkSystem : SingletonComponent<AfkSystem>, IGameEvents
 {
 	private const float SecondsPerMinute = 60f;
 	
-	private Dictionary<long, Vector3> _lastPlayerPositions = new();
+	private Dictionary<long, int> _lastPlayerInputActivitySequences = new();
 	private readonly Dictionary<long, TimeSince> _playerIdleTime = new();
 
 	private TimeSince _timeSinceLastAfkCheck = 0f;
@@ -33,7 +33,7 @@ public class AfkSystem : SingletonComponent<AfkSystem>, IGameEvents
 		_timeSinceLastAfkCheck = 0f;
 
 		var config = Config.Current.Game;
-		var currentPlayerPositions = new Dictionary<long, Vector3>();
+		var currentPlayerInputActivitySequences = new Dictionary<long, int>();
 
 		foreach ( var player in GameUtils.Players )
 		{
@@ -42,51 +42,51 @@ public class AfkSystem : SingletonComponent<AfkSystem>, IGameEvents
 				continue;
 			}
 
-			var currentPosition = player.WorldPosition;
-			currentPlayerPositions[player.SteamId] = currentPosition;
+			var currentInputActivitySequence = player.AfkInputActivitySequence;
+			currentPlayerInputActivitySequences[player.SteamId] = currentInputActivitySequence;
 
-			if ( !_lastPlayerPositions.TryGetValue( player.SteamId, out var lastPosition ) )
+			if ( !_lastPlayerInputActivitySequences.TryGetValue( player.SteamId, out var lastInputActivitySequence ) )
 			{
 				// First time seeing this player, initialize their idle timer
 				_playerIdleTime[player.SteamId] = 0f;
 				continue;
 			}
 
-			var distanceMoved = lastPosition.Distance( currentPosition );
+			var hasInputActivity = currentInputActivitySequence != lastInputActivitySequence;
 
-			if ( distanceMoved <= config.AfkMovementThreshold )
+			if ( !hasInputActivity )
 			{
-				// Player hasn't moved enough
+				// Player did not provide real owner input since the last check.
 				_playerIdleTime.TryAdd( player.SteamId, 0f );
 
 				var idleTime = _playerIdleTime[player.SteamId];
 
 				// Only add AFK status if they've been idle for X minutes
-				if ( idleTime >= Config.Current.Game.TimeUntilAfk )
+				if ( idleTime >= config.TimeUntilAfk )
 				{
 					player.AddStatus( Constants.AfkStatus );
 				}
 
 				// Demote to Citizen if AFK for more than 60 minutes
-				if ( Config.Current.Game.AfkDemoteEnabled && idleTime >= Config.Current.Game.TimeUntilAfkDemote )
+				if ( config.AfkDemoteEnabled && idleTime >= config.TimeUntilAfkDemote )
 				{
 					if ( !player.Job.IsCitizenRole() && player.Job.Selectable )
 					{
 						player.AssignJobHost( GameModeJobs.GetByTagOrFallback( JobTag.Citizen, "Citizen" ) );
-						var minutesAfk = Config.Current.Game.TimeUntilAfkDemote / SecondsPerMinute;
+						var minutesAfk = config.TimeUntilAfkDemote / SecondsPerMinute;
 						player.SendMessage( $"You have been demoted to Citizen due to being AFK for {minutesAfk} minutes." );
 					}
 				}
 			}
 			else
 			{
-				// Player moved, reset their idle timer and remove AFK status
+				// Player used keyboard/mouse input, reset their idle timer and remove AFK status.
 				_playerIdleTime[player.SteamId] = 0f;
 				player.RemoveStatus( Constants.AfkStatus );
 			}
 		}
 
-		_lastPlayerPositions = currentPlayerPositions;
+		_lastPlayerInputActivitySequences = currentPlayerInputActivitySequences;
 	}
 
 	public void ForceAfk( Player player )
@@ -99,13 +99,13 @@ public class AfkSystem : SingletonComponent<AfkSystem>, IGameEvents
 		}
 
 		player.AddStatus( Constants.AfkStatus );
-		_lastPlayerPositions.Remove( player.SteamId );
-		_playerIdleTime.Remove( player.SteamId );
+		_lastPlayerInputActivitySequences[player.SteamId] = player.AfkInputActivitySequence;
+		_playerIdleTime[player.SteamId] = 0f;
 	}
 
 	public void OnPlayerDisconnectHost( long steamId )
 	{
-		_lastPlayerPositions.Remove( steamId );
+		_lastPlayerInputActivitySequences.Remove( steamId );
 		_playerIdleTime.Remove( steamId );
 	}
 }


### PR DESCRIPTION
This changes the AFK system so it no longer uses player world position as the activity signal. Previously, any external movement could reset AFK state, including props, forcers, or anti-AFK machines pushing the player around.
AFK activity is now based on real owner input from the player, such as keyboard/mouse actions and look movement. The client reports a lightweight activity sequence to the host, and the AFK system compares that sequence during its normal checks.
This means only intentional player input clears AFK, while forced physical movement no longer prevents AFK detection.