### PR TITLE
fix(feedback): prevent screenshot capture thread crash (#185)

### DIFF
--- a/game/Code/UI/Feedback/FeedbackForm.razor.cs
+++ b/game/Code/UI/Feedback/FeedbackForm.razor.cs
@@ -106,13 +106,28 @@ public partial class FeedbackForm
 		_status = SubmitStatus.None;
 		StateHasChanged();
 
-		byte[]? screenshot = null;
-		if ( _includeScreenshot && CaptureScreenshot != null )
+		FeedbackSubmitResult result;
+		string? issueUrl;
+
+		try
 		{
-			screenshot = await CaptureScreenshot();
+			byte[]? screenshot = null;
+			if ( _includeScreenshot && CaptureScreenshot != null )
+			{
+				screenshot = await CaptureScreenshot();
+			}
+
+			( result, issueUrl ) = await PlayerApiClient.SubmitFeedback( _type, _title.Trim(), _description.Trim(), screenshot );
+		}
+		catch ( Exception ex )
+		{
+			Log.Error( $"Failed to submit feedback: {ex.Message}" );
+			result = FeedbackSubmitResult.Failed;
+			issueUrl = null;
 		}
 
-		var ( result, issueUrl ) = await PlayerApiClient.SubmitFeedback( _type, _title.Trim(), _description.Trim(), screenshot );
+		// Both screenshot encoding and the API request run off the UI thread.
+		await GameTask.MainThread();
 
 		_isSubmitting = false;
 		_issueUrl = issueUrl;

--- a/game/Code/UI/Feedback/FeedbackPopup.razor.cs
+++ b/game/Code/UI/Feedback/FeedbackPopup.razor.cs
@@ -22,6 +22,10 @@ public partial class FeedbackPopup
 	// HUD, so everything else (chat, health, etc.) stays visible in the capture.
 	private async Task<byte[]?> CaptureScreenshot()
 	{
+		// UI callbacks normally start on the main thread, but their continuations do not
+		// necessarily stay there. All scene and render-target work must remain on it.
+		await GameTask.MainThread();
+
 		if ( !Scene.Camera.IsValid() )
 		{
 			return null;
@@ -34,23 +38,32 @@ public partial class FeedbackPopup
 		// Give the hidden state a couple of real frames to actually render before capturing.
 		await GameTask.DelayRealtime( 50 );
 
-		var texture = Texture.CreateRenderTarget().WithSize( (int)Screen.Width, (int)Screen.Height ).Create();
-		byte[] png;
+		// DelayRealtime resumes on a worker thread. Return to the main thread before
+		// interacting with the camera or GPU resources.
+		await GameTask.MainThread();
+
+		Texture? texture = null;
+		byte[]? png = null;
 
 		try
 		{
-			Scene.Camera.RenderToTexture( texture );
+			if ( Scene.Camera.IsValid() )
+			{
+				texture = Texture.CreateRenderTarget().WithSize( (int)Screen.Width, (int)Screen.Height ).Create();
+				Scene.Camera.RenderToTexture( texture );
 
-			await GameTask.WorkerThread();
-			var bitmap = texture.GetBitmap( 0 );
-			png = bitmap.ToPng();
+				await GameTask.WorkerThread();
+				using var bitmap = texture.GetBitmap( 0 );
+				png = bitmap.ToPng();
+			}
 		}
-		finally
+		catch ( Exception ex )
 		{
-			texture.Dispose();
+			Log.Error( $"Failed to capture feedback screenshot: {ex.Message}" );
 		}
 
 		await GameTask.MainThread();
+		texture?.Dispose();
 		_capturing = false;
 		StateHasChanged();
 


### PR DESCRIPTION
## Summary

Fixes a crash when submitting feedback with a screenshot attached.

After the screenshot-capture delay, the continuation could resume on a worker thread. The code could then access the camera and GPU render target off the main thread, causing a crash.

The capture flow now explicitly returns to the main thread before interacting with the camera or render target. Bitmap readback and PNG encoding remain on a worker thread to avoid blocking the UI, and the form only updates its state after returning to the main thread.

- Prevents off-thread camera and GPU access.
- Keeps image encoding off the UI thread.
- Handles capture failures gracefully while still allowing feedback to be submitted.

Fixes #185 