### PR TITLE
fix(ui): darken rolling table buttons (#181)

### DIFF
--- a/game/Code/UI/Gameplay/Entities/RollingTable/RollingTableEntityDisplay.razor
+++ b/game/Code/UI/Gameplay/Entities/RollingTable/RollingTableEntityDisplay.razor
@@ -63,7 +63,7 @@
 	                <button class="btn btn-good text-lg flex-1" @onclick="@(() => OnMakeProduct(true))">
 	                    <span>#rollingtable.roll_joints</span>
 	                </button>
-	                <button class="btn text-lg flex-1" style="background-color: #556B2F;" @onclick="@(() => OnMakeProduct(false))">
+	                <button class="btn btn-olive text-lg flex-1" @onclick="@(() => OnMakeProduct(false))">
 	                    <span>#rollingtable.pack_bundle</span>
 	                </button>
 	            </div>

--- a/game/Code/UI/Gameplay/Entities/RollingTable/RollingTableEntityDisplay.razor.scss
+++ b/game/Code/UI/Gameplay/Entities/RollingTable/RollingTableEntityDisplay.razor.scss
@@ -12,10 +12,63 @@ RollingTableEntityDisplay {
     
     color: white;
 
-    button {
-        &[disabled] {
-            opacity: 0.5;
-            cursor: not-allowed;
+    button.btn {
+        background-color: #25272b;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.55);
+        color: white;
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.75);
+        transition: transform 0.2s, background-color 0.2s;
+
+        &:hover {
+            background-color: #303338;
+        }
+
+        &.btn-primary {
+            background-color: #3e3d91;
+
+            &:hover {
+                background-color: #4a49a5;
+            }
+        }
+
+        &.btn-secondary {
+            background-color: #1d1f23;
+
+            &:hover {
+                background-color: #282b30;
+            }
+        }
+
+        &.btn-good {
+            background-color: #176c32;
+
+            &:hover {
+                background-color: #1d7c3b;
+            }
+        }
+
+        &.btn-olive {
+            background-color: #405222;
+
+            &:hover {
+                background-color: #4c6129;
+            }
+        }
+    }
+
+    button.btn[disabled] {
+        opacity: 1;
+        background-color: #151619;
+        border-color: rgba(255, 255, 255, 0.06);
+        box-shadow: none;
+        color: rgba(255, 255, 255, 0.42);
+        cursor: not-allowed;
+        text-shadow: none;
+
+        &:hover {
+            background-color: #151619;
+            transform: none;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Make rolling-table buttons darker and opaque to prevent them looking washed out against world lighting.
- Keep semantic button colors for primary, secondary, good, and olive actions.
- Remove the inline olive background in favor of a scoped CSS class.

<img width="1040" height="645" alt="image" src="https://github.com/user-attachments/assets/8ea854d6-1d62-4ac7-b655-d3d8ff619b89" />
