### PR TITLE
fix(wire): avoid rendering camera feeds for off-screen screens (#182)

### DIFF
--- a/game/Code/Construct/Constructs/Wire/ScreenWire/ScreenWire.cs
+++ b/game/Code/Construct/Constructs/Wire/ScreenWire/ScreenWire.cs
@@ -27,6 +27,7 @@ public class ScreenWire() : BaseWireConstruct( ConstructType.ScreenWire ), IWire
 	private DisplayMode _mode = DisplayMode.Text;
 
 	private bool _playerWithinRaycast;
+	private bool _wasVisibleToPlayer;
 
 	private CameraWire? _cachedCameraWire;
 
@@ -88,17 +89,25 @@ public class ScreenWire() : BaseWireConstruct( ConstructType.ScreenWire ), IWire
 		{
 			return;
 		}
-
-		if ( !Cooldown.Current.CheckAndStartCooldown( $"camera:{Id}", Config.Current.Game.WireScreenCameraRaycastInterval ) )
+		if ( !RenderWireScreenCamera )
 		{
-			if ( !RenderWireScreenCamera )
-			{
-				_playerWithinRaycast = false;
-			}
-			else
-			{
-				RaycastPlayerCheck();
-			}
+			_playerWithinRaycast = false;
+			_wasVisibleToPlayer = false;
+			return;
+		}
+
+		if ( !IsVisibleToPlayer() )
+		{
+			_playerWithinRaycast = false;
+			_wasVisibleToPlayer = false;
+			return;
+		}
+
+		var raycastIntervalElapsed = !Cooldown.Current.CheckAndStartCooldown( $"camera:{Id}", Config.Current.Game.WireScreenCameraRaycastInterval );
+		if ( !_wasVisibleToPlayer || raycastIntervalElapsed )
+		{
+			_wasVisibleToPlayer = true;
+			RaycastPlayerCheck();
 		}
 
 		if ( !_playerWithinRaycast )
@@ -126,6 +135,25 @@ public class ScreenWire() : BaseWireConstruct( ConstructType.ScreenWire ), IWire
 			.Run();
 
 		_playerWithinRaycast = tr.GameObject == GameObject;
+	}
+
+	private bool IsVisibleToPlayer()
+	{
+		var camera = Scene.Camera;
+		if ( !camera.IsValid() )
+		{
+			return false;
+		}
+
+		var directionToScreen = (GameObject.WorldPosition - camera.WorldPosition).Normal;
+		if ( Vector3.Dot( camera.WorldRotation.Forward, directionToScreen ) < 0 )
+		{
+			return false;
+		}
+
+		var screenPosition = camera.PointToScreenNormal( GameObject.WorldPosition );
+		return screenPosition.x is >= 0 and <= 1
+			&& screenPosition.y is >= 0 and <= 1;
 	}
 
 	private void OnCurrentValueChanged( string oldValue, string newValue )
@@ -216,8 +244,6 @@ public class ScreenWire() : BaseWireConstruct( ConstructType.ScreenWire ), IWire
 		// Update top area of the camera texture with header bytes
 		_cameraTexture.Update( _cachedHeaderBytesCamera, 0, 0, (int)textureWidth, headerHeight );
 
-		// Ensure DisplayRenderer material is using the camera texture
-		UpdateScreenTexture();
 	}
 
 	private void CleanupCameraTexture()


### PR DESCRIPTION
## Summary

Optimizes Wire screen camera rendering to reduce FPS drops when multiple screens are present.

Camera feeds now render only when their screen is visible in the player’s viewport. Screens behind the player or outside the viewport stop updating immediately, then refresh as soon as they enter view.

Also removes a redundant material override during camera updates.

## Expected impact

This should significantly reduce unnecessary `RenderToTexture` calls when several camera screens exist nearby but are not currently visible, helping mitigate FPS drops without reducing the update rate of screens being viewed.