### PR TITLE
fix(snapshot): persist money pots and keypads across server restarts (#60)

### DIFF
--- a/game/Code/Construct/Construct.Handler.cs
+++ b/game/Code/Construct/Construct.Handler.cs
@@ -656,7 +656,8 @@ public partial class Construct
 		bool addUndo = false,
 		int delayBetweenItems = 0,
 		int delayBetweenWires = 50,
-		CancellationToken cancellationToken = default )
+		CancellationToken cancellationToken = default,
+		Action<ConstructDupeItem, IConstruct>? onConstructSpawned = null )
 	{
 		Assert.True( Networking.IsHost );
 
@@ -704,6 +705,7 @@ public partial class Construct
 			{
 				spawnedItems.Add( construct );
 				idToConstructMap[dupeItem.Id] = construct;
+				onConstructSpawned?.Invoke( dupeItem, construct );
 
 			}
 

--- a/game/Code/Construct/Constructs/Wire/KeypadWire/KeypadWire.cs
+++ b/game/Code/Construct/Constructs/Wire/KeypadWire/KeypadWire.cs
@@ -3,7 +3,7 @@
 [Title( "Keypad" )]
 [Category( "Wire" )]
 [Icon( "cable" )]
-public class KeypadWire() : BaseWireConstruct( ConstructType.KeypadWire ), IWireEvents
+public class KeypadWire() : BaseWireConstruct( ConstructType.KeypadWire ), IWireEvents, IConstructRuntimeState
 {
 	[Property]
 	private SoundEvent? FailSound { get; set; }
@@ -167,5 +167,30 @@ public class KeypadWire() : BaseWireConstruct( ConstructType.KeypadWire ), IWire
 	}
 
 	public event Action<string>? OnSuccessfulCodeReceived;
+
+	string IConstructRuntimeState.SaveRuntimeState()
+	{
+		return Json.Serialize( new KeypadWireRuntimeState
+		{
+			Code = _code,
+			Initialized = Initialized,
+			Output = Out
+		} );
+	}
+
+	void IConstructRuntimeState.LoadRuntimeState( string stateJson )
+	{
+		var state = Json.Deserialize<KeypadWireRuntimeState>( stateJson );
+		var code = state?.Code ?? string.Empty;
+		if ( state == null || code.Length > Wire.MaxWireStringLength )
+		{
+			return;
+		}
+
+		_code = state.Initialized ? code : string.Empty;
+		Initialized = state.Initialized;
+		Out = state.Initialized ? state.Output : _data.OffValue;
+		BroadcastInitializedState( state.Initialized );
+	}
 
 }

--- a/game/Code/Construct/Constructs/Wire/KeypadWire/KeypadWireData.cs
+++ b/game/Code/Construct/Constructs/Wire/KeypadWire/KeypadWireData.cs
@@ -9,3 +9,10 @@ public record KeypadWireData : IConstructData, IWireLabelData
 	public bool Toggle { get; set; }
 	public string Label { get; set; } = string.Empty;
 }
+
+public record KeypadWireRuntimeState
+{
+	public string Code { get; set; } = string.Empty;
+	public bool Initialized { get; set; }
+	public float Output { get; set; }
+}

--- a/game/Code/Construct/Constructs/Wire/MoneyPotWire/MoneyPotWire.cs
+++ b/game/Code/Construct/Constructs/Wire/MoneyPotWire/MoneyPotWire.cs
@@ -6,7 +6,7 @@ namespace Dxura.RP.Game.Wire;
 [Title( "MoneyPot" )]
 [Category( "Wire" )]
 [Icon( "attach_money" )]
-public class MoneyPotWire() : BaseWireConstruct( ConstructType.MoneyPotWire ), Component.IPressable, Component.ITriggerListener
+public class MoneyPotWire() : BaseWireConstruct( ConstructType.MoneyPotWire ), Component.IPressable, Component.ITriggerListener, IConstructRuntimeState
 {
 	[WireOutput( "total_amount" )]
 	private uint Amount { get; set; }
@@ -197,5 +197,30 @@ public class MoneyPotWire() : BaseWireConstruct( ConstructType.MoneyPotWire ), C
 		}
 
 		base.OnDestroy();
+	}
+
+	string IConstructRuntimeState.SaveRuntimeState()
+	{
+		lock ( MoneyLock )
+		{
+			return Json.Serialize( new MoneyPotWireRuntimeState { Amount = Amount } );
+		}
+	}
+
+	void IConstructRuntimeState.LoadRuntimeState( string stateJson )
+	{
+		var state = Json.Deserialize<MoneyPotWireRuntimeState>( stateJson );
+		if ( state == null )
+		{
+			return;
+		}
+
+		lock ( MoneyLock )
+		{
+			Amount = state.Amount;
+		}
+
+		DisplayAmount = state.Amount;
+		BroadcastDisplayAmount( state.Amount );
 	}
 }

--- a/game/Code/Construct/Constructs/Wire/MoneyPotWire/MoneyPotWireData.cs
+++ b/game/Code/Construct/Constructs/Wire/MoneyPotWire/MoneyPotWireData.cs
@@ -5,3 +5,8 @@ public record MoneyPotWireData : IConstructData, IWireLabelData
 	public uint SchemaVersion => 1;
 	public string Label { get; set; } = string.Empty;
 }
+
+public record MoneyPotWireRuntimeState
+{
+	public uint Amount { get; set; }
+}

--- a/game/Code/Construct/IConstructRuntimeState.cs
+++ b/game/Code/Construct/IConstructRuntimeState.cs
@@ -1,0 +1,10 @@
+namespace Dxura.RP.Game;
+
+/// <summary>
+/// Runtime state that is persisted as part of a server snapshot, but never included in player dupes.
+/// </summary>
+public interface IConstructRuntimeState
+{
+	string SaveRuntimeState();
+	void LoadRuntimeState( string stateJson );
+}

--- a/game/Code/System/Recovery/Data/ConstructRuntimeSnapshotData.cs
+++ b/game/Code/System/Recovery/Data/ConstructRuntimeSnapshotData.cs
@@ -1,0 +1,11 @@
+namespace Dxura.RP.Game;
+
+/// <summary>
+/// Runtime state for a construct in a server snapshot. This is intentionally separate from ConstructDupeItem.
+/// </summary>
+public class ConstructRuntimeSnapshotData
+{
+	public Guid ConstructId { get; set; }
+	public ConstructType Type { get; set; }
+	public string StateJson { get; set; } = string.Empty;
+}

--- a/game/Code/System/Recovery/Data/Snapshot.cs
+++ b/game/Code/System/Recovery/Data/Snapshot.cs
@@ -3,6 +3,7 @@
 public class Snapshot
 {
 	public ConstructDupe? WorldDupe { get; set; }
+	public List<ConstructRuntimeSnapshotData> ConstructRuntimeStates { get; set; } = new();
 	public List<PlayerSnapshotData> Players { get; set; } = new();
 
 	// Game objects are stored as whole, mostly for entities with too much state.

--- a/game/Code/System/Recovery/SnapshotSystem.cs
+++ b/game/Code/System/Recovery/SnapshotSystem.cs
@@ -175,6 +175,7 @@ public class SnapshotSystem : GameObjectSystem<SnapshotSystem>, IGameEvents
 			{
 				snapshot.WorldDupe = dupe;
 				savedConstructs = dupe.Items.Count();
+				SaveConstructRuntimeStates( snapshot, dupe );
 			}
 		}
 		catch ( Exception e )
@@ -334,11 +335,16 @@ public class SnapshotSystem : GameObjectSystem<SnapshotSystem>, IGameEvents
 			if ( dupeItemCount > 0 )
 			{
 				Log.Info( $"{LogPrefix} Restoring {dupeItemCount} constructs and {file.WorldDupe.WireConnections.Count()} wire connections." );
+				var runtimeStates = file.ConstructRuntimeStates
+					.GroupBy( state => state.ConstructId )
+					.ToDictionary( group => group.Key, group => group.Last() );
+
 				_ = Construct.Current.SpawnDupeItems(
 					file.WorldDupe,
 					null,
 					enforceLimits: false,
-					addUndo: true
+					addUndo: true,
+					onConstructSpawned: ( dupeItem, construct ) => RestoreConstructRuntimeState( runtimeStates, dupeItem, construct )
 				);
 			}
 			else
@@ -404,6 +410,53 @@ public class SnapshotSystem : GameObjectSystem<SnapshotSystem>, IGameEvents
 		_cleanupSchedule.Remove( 0 );
 
 		Log.Info( $"{LogPrefix} Scheduled cleanup for {_cleanupSchedule.Count} players (grace={Config.Current.Game.GraceReconnectTime}s)" );
+	}
+
+	private void SaveConstructRuntimeStates( Snapshot snapshot, ConstructDupe dupe )
+	{
+		var duplicatedConstructIds = dupe.Items.Select( item => item.Id ).ToHashSet();
+
+		foreach ( var construct in Scene.GetAll<IConstruct>() )
+		{
+			if ( !construct.IsValid() || !duplicatedConstructIds.Contains( construct.Id ) || construct is not IConstructRuntimeState runtimeState )
+			{
+				continue;
+			}
+
+			try
+			{
+				snapshot.ConstructRuntimeStates.Add( new ConstructRuntimeSnapshotData
+				{
+					ConstructId = construct.Id,
+					Type = construct.Type,
+					StateJson = runtimeState.SaveRuntimeState()
+				} );
+			}
+			catch ( Exception e )
+			{
+				Log.Warning( $"{LogPrefix} Failed to save runtime state for construct {construct.Id}: {e.Message}" );
+			}
+		}
+	}
+
+	private void RestoreConstructRuntimeState(
+		IReadOnlyDictionary<Guid, ConstructRuntimeSnapshotData> runtimeStates,
+		ConstructDupeItem dupeItem,
+		IConstruct construct )
+	{
+		if ( !runtimeStates.TryGetValue( dupeItem.Id, out var state ) || state.Type != construct.Type || construct is not IConstructRuntimeState runtimeState )
+		{
+			return;
+		}
+
+		try
+		{
+			runtimeState.LoadRuntimeState( state.StateJson );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"{LogPrefix} Failed to restore runtime state for construct {dupeItem.Id}: {e.Message}" );
+		}
 	}
 
 	public PlayerSnapshotData? TakePlayerData( long steamId )


### PR DESCRIPTION
## Summary

Persists runtime-only state for money pots and keypads in server snapshots.

- Restores money pot balances after a server restart.
- Restores keypad codes, initialization state, and current output.
- Keeps this state separate from construct data and dupes, preventing balances or codes from being copied through duplication.

Closes #60