### PR TITLE
feat(wire) : Add string contains gate wire (#179)

### DIFF
--- a/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
+++ b/game/Code/Construct/Constructs/Wire/GateWire/GateWire.cs
@@ -43,6 +43,22 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 		_data = newData as GateWireData ?? new GateWireData();
 	}
 
+	public override IEnumerable<WirePort> GetInputPorts()
+	{
+		var inputCount = GetOperandInputCount( _data.Type );
+
+		return base.GetInputPorts().Where( port => port.Id switch
+		{
+			"a" => inputCount >= 1,
+			"b" => inputCount >= 2,
+			"c" => inputCount >= 3,
+			"d" => inputCount >= 4,
+			"e" => inputCount >= 5,
+			"process" => true,
+			_ => false
+		} );
+	}
+
 	protected override void OnStart()
 	{
 		base.OnStart();
@@ -190,6 +206,9 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 			GateType.Substring => ProcessSubstring( strA, numB, numC ),
 			GateType.ToUpper => strA.ToUpper(),
 			GateType.ToLower => strA.ToLower(),
+			GateType.Contains => strA.Contains( strB, StringComparison.Ordinal )
+				? GateWireDefinition.GateLogicHigh
+				: GateWireDefinition.GateLogicLow,
 
 			// Time functions
 			GateType.Time => Time.Now,
@@ -242,6 +261,32 @@ public class GateWire() : BaseWireConstruct( ConstructType.GateWire ), IWireEven
 			bool b => b ? 1f : 0f,
 			string s when float.TryParse( s, out var f ) => f,
 			_ => 0f
+		};
+	}
+
+	private static int GetOperandInputCount( GateType type )
+	{
+		return type switch
+		{
+			GateType.And or GateType.Or or GateType.Nand or GateType.Nor or
+			GateType.Add or GateType.Subtract or GateType.Concat => 5,
+
+			GateType.If or GateType.Clamp or GateType.Lerp or GateType.Select or
+			GateType.Substring or GateType.Vector3 => 3,
+
+			GateType.Xor or GateType.Multiply or GateType.Divide or GateType.Modulo or
+			GateType.Power or GateType.Min or GateType.Max or GateType.Equal or
+			GateType.NotEqual or GateType.GreaterThan or GateType.LessThan or
+			GateType.GreaterEqual or GateType.LessEqual or GateType.Random or
+			GateType.Round or GateType.Threshold or GateType.Latch or GateType.Contains or
+			GateType.Vector2 or GateType.VectorGet => 2,
+
+			GateType.Not or GateType.Abs or GateType.Floor or GateType.Ceiling or
+			GateType.Sin or GateType.Cos or GateType.Tan or GateType.Sqrt or GateType.Log or
+			GateType.Invert or GateType.Length or GateType.ToUpper or GateType.ToLower => 1,
+
+			GateType.Time or GateType.DeltaTime => 0,
+			_ => 5
 		};
 	}
 

--- a/game/Code/Construct/Constructs/Wire/GateWire/GateWireData.cs
+++ b/game/Code/Construct/Constructs/Wire/GateWire/GateWireData.cs
@@ -75,6 +75,7 @@ public enum GateType
 	Substring = 502,
 	ToUpper = 503,
 	ToLower = 504,
+	Contains = 505,
 
 	// Time functions (600-699)
 	Time = 600,

--- a/game/Localization/en/dxrp.json
+++ b/game/Localization/en/dxrp.json
@@ -819,6 +819,7 @@
   "gatetype.substring": "Substring (extract from A at index B, length C → Out)",
   "gatetype.toupper": "To Upper (upper(A) → Out)",
   "gatetype.tolower": "To Lower (lower(A) → Out)",
+  "gatetype.contains": "Contains (A contains B → Out)",
   "gatetype.time": "Time (current time → Out)",
   "gatetype.deltatime": "Delta Time (frame time → Out)",
   "gatetype.vector2": "Vector2 ( (A, B) → Out )",

--- a/game/Localization/fr/dxrp.json
+++ b/game/Localization/fr/dxrp.json
@@ -717,6 +717,7 @@
   "gatetype.substring": "Sous-chaîne (A à l'index B, longueur C → Out)",
   "gatetype.toupper": "Majuscules (upper(A) → Out)",
   "gatetype.tolower": "Minuscules (lower(A) → Out)",
+  "gatetype.contains": "Contient (A contient B → Out)",
   "gatetype.time": "Temps (temps actuel → Out)",
   "gatetype.deltatime": "Delta Time (temps par frame → Out)",
   "gatetype.vector2": "Vecteur2 ( (A, B) → Out )",

--- a/game/Localization/ko/dxrp.json
+++ b/game/Localization/ko/dxrp.json
@@ -717,6 +717,7 @@
   "gatetype.substring": "부분 문자열 (A에서 B 위치부터 C 길이 추출 → 출력)",
   "gatetype.toupper": "대문자 변환 (upper(A) → 출력)",
   "gatetype.tolower": "소문자 변환 (lower(A) → 출력)",
+  "gatetype.contains": "포함 (A에 B 포함 → 출력)",
   "gatetype.time": "현재 시간 (time → 출력)",
   "gatetype.deltatime": "프레임 시간 (delta time → 출력)",
   "gatetype.vector2": "벡터2 (A, B → 출력)",

--- a/game/Localization/pl/dxrp.json
+++ b/game/Localization/pl/dxrp.json
@@ -717,6 +717,7 @@
   "gatetype.substring": "Podtekst (wyciąg z A od indeksu B, długość C → Wyj)",
   "gatetype.toupper": "Wielkie litery (upper(A) → Wyj)",
   "gatetype.tolower": "Małe litery (lower(A) → Wyj)",
+  "gatetype.contains": "Zawiera (A zawiera B → Wyj)",
   "gatetype.time": "Czas (aktualny czas → Wyj)",
   "gatetype.deltatime": "Czas klatki (czas klatki → Wyj)",
   "gatetype.vector2": "Wektor2 ( (A, B) → Wyj )",

--- a/game/Localization/ru/dxrp.json
+++ b/game/Localization/ru/dxrp.json
@@ -717,6 +717,7 @@
   "gatetype.substring": "Подстрока",
   "gatetype.toupper": "В ВЕРХНИЙ РЕГИСТР",
   "gatetype.tolower": "в нижний регистр",
+  "gatetype.contains": "Содержит (A содержит B)",
   "gatetype.time": "Текущее время",
   "gatetype.deltatime": "Дельта времени",
   "gatetype.vector2": "Вектор2 (A, B)",


### PR DESCRIPTION
### Gate logic and code changes

* Added a new `GateType.Contains` to the `GateType` enum in `GateWireData.cs`, enabling a gate that checks if string A contains string B.
* Implemented logic for the new "Contains" gate in `GateWire.cs`, including processing logic in `ProcessGate()` and updating the input port filtering in `GetInputPorts()` to handle the correct number of operands. [[1]](diffhunk://#diff-632dd2dde638a108e335c423c5ffc871fe58a4c1d7cd0d5f25733dc81f2da914R209-R211) [[2]](diffhunk://#diff-632dd2dde638a108e335c423c5ffc871fe58a4c1d7cd0d5f25733dc81f2da914R46-R61)
* Added a helper method `GetOperandInputCount()` to determine how many input ports each gate type should have, including the new "Contains" gate.

### Localization

* Added localized descriptions for the new "Contains" gate in English, French, Korean, Polish, and Russian localization files. [[1]](diffhunk://#diff-91ca20203a1484059318c148c0989d5c85669dc601219fa4bcf93393697bb027R822) [[2]](diffhunk://#diff-b2ca6a6699c4022c99b1c14054e1d17e51aff63311507cc4aed11285391bc931R720) [[3]](diffhunk://#diff-7072a4f0b8c7611c9148dcb9e4c1fea97d33cfec10188943e5edf7a1e28e0838R720) [[4]](diffhunk://#diff-4a6bfd3ed5c77b29ec844463a27d73ff71d3221ff77f443d514a87bf63a061b3R720) [[5]](diffhunk://#diff-1965ec34804fe114de0ef61466151ef31e3ac9b14e163021755f621494a0ac65R720)

Closes #179 